### PR TITLE
파티 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/MemberParty.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/MemberParty.java
@@ -1,12 +1,15 @@
 package nbbang.com.nbbang.domain.bbangpan.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.party.domain.Party;
 
 import javax.persistence.*;
 
-@Entity @Getter
+@Entity @Getter @Builder
+@AllArgsConstructor
 public class MemberParty {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,4 +25,6 @@ public class MemberParty {
     @ManyToOne
     @JoinColumn(name = "party_id")
     private Party party;
+
+    protected MemberParty() {}
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatController.java
@@ -15,8 +15,12 @@ import nbbang.com.nbbang.global.support.FileUpload.FileUploadService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.naming.Binding;
 
 @Tag(name = "Chat", description = "채팅방 api (로그인 구현시 올바른 토큰을 보내지 않을 경우 401 Unauthorized 메시지를 받습니다.).")
 @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json"))
@@ -69,19 +73,26 @@ public class ChatController {
     @ApiResponse(responseCode = "403", description = "Not Owner", content = @Content(mediaType = "application/json"))
     @PatchMapping("/{party-id}/status")
     public ResponseEntity changeStatus(@PathVariable("party-id") Long partyId,
-                                       @Schema(description = "채팅방 상태: 모집 중 - on, 마감 임박 - soon, 모집 완료 - full, 주문 완료 - finish, 모집 취소 - cancel")
-                                               ChatStatusChangeRequestDto chatStatusChangeRequestDto) {
+                                       @Validated @RequestBody ChatStatusChangeRequestDto chatStatusChangeRequestDto,
+                                       BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return new ResponseEntity(DefaultResponse.res(StatusCode.BAD_REQUEST, "잘못된 요청입니다. Status 를 올바르게 입력하세요."), HttpStatus.BAD_REQUEST);
+        }
         return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessage.UPDATE_CHAT), HttpStatus.OK);
     }
 
     @Operation(summary = "채팅방 최대 참여자 수 변경", description = "방장만 채팅방 속성을 변경할 수 있습니다.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json"))
-    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다. Status 를 올바르게 입력하세요.", content = @Content(mediaType = "application/json"))
+    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다. 참여자 수를 올바르게 입력하세요.", content = @Content(mediaType = "application/json"))
     @ApiResponse(responseCode = "403", description = "Not Owner", content = @Content(mediaType = "application/json"))
     @PatchMapping("/{party-id}/number")
     public ResponseEntity changeGoalNumber(@PathVariable("party-id") Long partyId,
-                                                @Schema(description = "채팅방 최대 참여자 수")
-                                                        ChatChangeGoalNumberRequestDto chatChangeGoalNumberRequestDto) {
+                                           @Schema(description = "채팅방 최대 참여자 수")
+                                           @Validated @RequestBody ChatChangeGoalNumberRequestDto chatChangeGoalNumberRequestDto,
+                                           BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return new ResponseEntity(DefaultResponse.res(StatusCode.BAD_REQUEST, "잘못된 요청입니다. 참여자 수를 올바르게 입력하세요."), HttpStatus.BAD_REQUEST);
+        }
         return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessage.UPDATE_CHAT), HttpStatus.OK);
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatChangeGoalNumberRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatChangeGoalNumberRequestDto.java
@@ -2,9 +2,13 @@ package nbbang.com.nbbang.domain.chat.dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @Data
 public class ChatChangeGoalNumberRequestDto {
+    @Max(10) @Min(2) @NotNull
     private Integer goalNumber;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatMessageSendRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatMessageSendRequestDto.java
@@ -3,7 +3,10 @@ package nbbang.com.nbbang.domain.chat.dto;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.validation.constraints.Size;
+
 @Data @Builder
 public class ChatMessageSendRequestDto {
+    @Size(max = 255)
     private String content;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatResponseDto.java
@@ -14,20 +14,20 @@ import java.util.List;
 public class ChatResponseDto {
 
     private String title;
+    private LocalDateTime createTime;
+    private Integer joinNumber;
+    private Integer goalNumber;
     private String status;
-    private Integer memberNumber;
-    private Integer maxMemberNumber;
     private MemberResponseDto owner;
     private List<MemberResponseDto> participants;
-    private LocalDateTime createTime;
     private List<ChatMessageResponseDto> chatMessages;
 
     public static ChatResponseDto createMock() {
         ChatResponseDto dto = ChatResponseDto.builder()
                 .title("뿌링클 오늘 7시")
                 .status("모집 중")
-                .memberNumber(3)
-                .maxMemberNumber(4)
+                .joinNumber(3)
+                .goalNumber(4)
                 .owner(MemberResponseDto.createLuffy())
                 .participants(Arrays.asList(MemberResponseDto.createKorung(), MemberResponseDto.createHyungKyung()))
                 .createTime(LocalDateTime.of(2022, 02, 12, 12, 40))

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatus.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatus.java
@@ -1,6 +1,0 @@
-package nbbang.com.nbbang.domain.chat.dto;
-
-public enum ChatStatus {
-    ON, SOON, FULL, FINISH, CANCEL,
-    on, soon, full, finish, cancel
-}

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatus.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatus.java
@@ -1,0 +1,6 @@
+package nbbang.com.nbbang.domain.chat.dto;
+
+public enum ChatStatus {
+    ON, SOON, FULL, FINISH, CANCEL,
+    on, soon, full, finish, cancel
+}

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatusChangeRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatusChangeRequestDto.java
@@ -1,8 +1,12 @@
 package nbbang.com.nbbang.domain.chat.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import nbbang.com.nbbang.global.support.validation.ValueOfEnum;
 
 @Data
 public class ChatStatusChangeRequestDto {
+    @ValueOfEnum(enumClass = ChatStatus.class) @Schema(description = "올바른 status 값: on, soon, full, finish, cancel")
     private String status;
 }
+

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatusChangeRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatStatusChangeRequestDto.java
@@ -2,11 +2,12 @@ package nbbang.com.nbbang.domain.chat.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import nbbang.com.nbbang.domain.party.domain.PartyStatus;
 import nbbang.com.nbbang.global.support.validation.ValueOfEnum;
 
 @Data
 public class ChatStatusChangeRequestDto {
-    @ValueOfEnum(enumClass = ChatStatus.class) @Schema(description = "올바른 status 값: on, soon, full, finish, cancel")
+    @ValueOfEnum(enumClass = PartyStatus.class) @Schema(description = "올바른 status 값: ON, SOON, FULL, FINISH, CANCEL")
     private String status;
 }
 

--- a/src/main/java/nbbang/com/nbbang/domain/member/controller/MemberController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/controller/MemberController.java
@@ -22,6 +22,8 @@ import nbbang.com.nbbang.global.support.FileUpload.FileUploadService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -46,8 +48,12 @@ public class MemberController {
 
     @Operation(summary = "마이페이지 정보 업데이트", description = "자신의 정보를 업데이트합니다.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json"))
+    @ApiResponse(responseCode = "400", description = "회원 정보를 올바르게 입력하세요.", content = @Content(mediaType = "application/json"))
     @PatchMapping
-    public ResponseEntity update(@RequestBody MemberUpdateRequestDto memberUpdateRequestDto) {
+    public ResponseEntity update(@Validated @RequestBody MemberUpdateRequestDto memberUpdateRequestDto, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return new ResponseEntity(DefaultResponse.res(StatusCode.BAD_REQUEST, "회원 정보를 올바르게 입력하세요."), HttpStatus.BAD_REQUEST);
+        }
         return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessage.UPDATE_USER), HttpStatus.OK);
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/member/domain/Member.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/domain/Member.java
@@ -1,10 +1,18 @@
 package nbbang.com.nbbang.domain.member.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import nbbang.com.nbbang.domain.member.dto.Place;
 
 import javax.persistence.*;
 
-@Entity @Getter
+import java.time.LocalDateTime;
+
+import static javax.persistence.EnumType.STRING;
+
+@Entity @Getter @Builder
+@AllArgsConstructor
 public class Member {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,6 +23,8 @@ public class Member {
 
     private String avatar;
 
-    private String place;
+    @Enumerated(STRING)
+    private Place place;
 
+    protected Member() {}
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/dto/MemberResponseDto.java
@@ -15,14 +15,14 @@ import lombok.NoArgsConstructor;
 public class MemberResponseDto {
     private String profileImagePath;
     private String nickname;
-    private String location;
+    private String place;
     private Integer recommends;
 
     public static MemberResponseDto createMock() {
         return MemberResponseDto.builder()
                 .profileImagePath("https://w.namu.la/s/bbff81cb4fd4d3f97d245a28a360b5cb665745b2cb434287f9cbd3423978919ce5377ef034f150277564c1798660ae95825fe2bfda50baa970f97d999a81c31401c0eb130e3bae0f9e1a2d3aea2a10769e564b0fbce08a8f23360382fd6e5425")
                 .nickname("식빵좋아")
-                .location("신촌동")
+                .place("신촌동")
                 .recommends(10)
                 .build();
     }
@@ -30,7 +30,7 @@ public class MemberResponseDto {
     public static MemberResponseDto createKorung() {
         return MemberResponseDto.builder()
                 .nickname("코렁")
-                .location("신촌동")
+                .place("신촌동")
                 .recommends(10)
                 .build();
     }
@@ -39,7 +39,7 @@ public class MemberResponseDto {
         return MemberResponseDto.builder()
                 .profileImagePath("https://w.namu.la/s/db854de68ffaa4ec688cc573a06d28d6b6e024c3fcd6160a6496103d0cacd5bfc3345a5dffc4c45b7591a97538ddc42280e0a57c9e2155ae90a836cff97436f10b1f8054e23a89ddd6f3d78fb58b99638995cfebd88e8994e3263a2895a2e73b")
                 .nickname("루피")
-                .location("신촌동")
+                .place("신촌동")
                 .recommends(10)
                 .build();
     }
@@ -47,7 +47,7 @@ public class MemberResponseDto {
     public static MemberResponseDto createHyungKyung() {
         return MemberResponseDto.builder()
                 .nickname("현경")
-                .location("신촌동")
+                .place("신촌동")
                 .recommends(10)
                 .build();
     }

--- a/src/main/java/nbbang/com/nbbang/domain/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/dto/MemberUpdateRequestDto.java
@@ -1,9 +1,16 @@
 package nbbang.com.nbbang.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import nbbang.com.nbbang.global.support.validation.ValueOfEnum;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Data
 public class MemberUpdateRequestDto {
+    @Size(min = 1, max = 16) @NotNull
     private String nickname;
-    private String email;
+    @ValueOfEnum(enumClass = Place.class) @Schema(description = "올바른 place 값: sinchon, ")
+    private String place;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/dto/MemberUpdateRequestDto.java
@@ -11,6 +11,6 @@ import javax.validation.constraints.Size;
 public class MemberUpdateRequestDto {
     @Size(min = 1, max = 16) @NotNull
     private String nickname;
-    @ValueOfEnum(enumClass = Place.class) @Schema(description = "올바른 place 값: sinchon, ")
+    @ValueOfEnum(enumClass = Place.class) @Schema(description = "올바른 place 값: SINCHON, ")
     private String place;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/dto/Place.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/dto/Place.java
@@ -1,5 +1,5 @@
 package nbbang.com.nbbang.domain.member.dto;
 
 public enum Place {
-    sinchon,
+    SINCHON,
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/dto/Place.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/dto/Place.java
@@ -1,0 +1,5 @@
+package nbbang.com.nbbang.domain.member.dto;
+
+public enum Place {
+    sinchon,
+}

--- a/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
@@ -6,11 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
 import nbbang.com.nbbang.domain.party.dto.PartyFindResponseDto;
 import nbbang.com.nbbang.domain.party.dto.PartyListResponseDto;
+import nbbang.com.nbbang.domain.party.service.PartyService;
 import nbbang.com.nbbang.global.response.*;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,7 +33,11 @@ import static org.springframework.http.HttpStatus.*;
         @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json"))
 })
 @Slf4j
+@RequiredArgsConstructor
 public class ManyPartyController {
+
+    private final PartyService partyService;
+
     @Operation(summary = "여러 개 파티 리스트 조회", description = "여러 개의 파티 리스트를 전송합니다. json이 아닌 query parameter로 데이터를 전송해야 합니다.")
     @ApiResponse(responseCode = "200", description = "OK",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
@@ -43,6 +51,10 @@ public class ManyPartyController {
 /*        System.out.println("partyFindRequestDto.getPlaces().size() = " + partyFindRequestDto.getPlaces().size());
         partyFindRequestDto.getPlaces().stream().forEach(System.out::println);
         System.out.println("partyFindRequestDto.isOngoing() "+ partyFindRequestDto.isOngoing());*/
-        return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessageParty.PARTY_FIND_SUCCESS, PartyListResponseDto.createMock()), OK);
+
+        Page<Party> resultEntities = partyService.findAll(partyFindRequestDto.createPageRequest());
+        PartyListResponseDto resultDto = PartyListResponseDto.createFromEntity(resultEntities.getContent());
+        //PartyListResponseDto resultDto = PartyListResponseDto.createMock();
+        return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessageParty.PARTY_FIND_SUCCESS, resultDto), OK);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/domain/Hashtag.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/domain/Hashtag.java
@@ -1,10 +1,14 @@
 package nbbang.com.nbbang.domain.party.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@Entity @Getter
+@Entity @Getter @Builder
+@AllArgsConstructor
 public class Hashtag {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hashtag_id")
@@ -15,4 +19,6 @@ public class Hashtag {
     @ManyToOne
     @JoinColumn(name = "party_id")
     private Party party;
+
+    protected Hashtag() {}
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
@@ -1,14 +1,22 @@
 package nbbang.com.nbbang.domain.party.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nbbang.com.nbbang.domain.bbangpan.domain.MemberParty;
 import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.dto.Place;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+import java.util.List;
+
 import static javax.persistence.EnumType.STRING;
 
-@Entity @Getter
+@Entity @Getter @Builder
+@AllArgsConstructor
 public class Party {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "party_id")
@@ -24,9 +32,10 @@ public class Party {
     private Integer goalNumber;
 
     @Enumerated(STRING)
-    private Status status;
+    private PartyStatus status;
 
-    private String place;
+    @Enumerated(STRING)
+    private Place place;
 
     private LocalDateTime cancelTime;
 
@@ -38,4 +47,11 @@ public class Party {
 
     private Boolean isBlocked;
 
+    @OneToMany(mappedBy = "party")
+    private List<Hashtag> hashtags;
+
+    @OneToMany(mappedBy = "party")
+    private List<MemberParty> memberParties;
+
+    protected Party() {}
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/domain/PartyStatus.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/domain/PartyStatus.java
@@ -2,6 +2,6 @@ package nbbang.com.nbbang.domain.party.domain;
 
 /*모집 중, 마감 임박, 모집 완료, 주문 완료, 모집 취소*/
 
-public enum Status {
+public enum PartyStatus {
     ON, SOON, FULL, ORDER, CANCEL
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestDto.java
@@ -3,15 +3,16 @@ package nbbang.com.nbbang.domain.party.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import nbbang.com.nbbang.global.dto.PageableDto;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public
-class PartyFindRequestDto{
+public class PartyFindRequestDto extends PageableDto {
     private List<String> places;
-    private boolean isOngoing;
-
+    private Boolean isOngoing;
+    private String search;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindResponseDto.java
@@ -1,13 +1,18 @@
 package nbbang.com.nbbang.domain.party.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import nbbang.com.nbbang.domain.party.domain.Party;
 
+import javax.servlet.http.Part;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
-@Data
+@Data @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PartyFindResponseDto{
@@ -16,6 +21,29 @@ public class PartyFindResponseDto{
     private Integer joinNumber;
     private Integer goalNumber;
     private String status;
+    private String place;
     private List<String> hashtags;
 
+    public static PartyFindResponseDto createMock() {
+        return PartyFindResponseDto.builder()
+                .title("연희동 올리브영 앞 BHC 7시")
+                .createTime(LocalDateTime.now())
+                .joinNumber(3)
+                .goalNumber(4)
+                .status("SOON")
+                .hashtags(Arrays.asList("BHC", "치킨"))
+                .build();
+    }
+
+    public static PartyFindResponseDto createByEntity(Party party) {
+        return PartyFindResponseDto.builder()
+                .title(party.getTitle())
+                .createTime(party.getCreateTime())
+                .goalNumber(party.getGoalNumber())
+                .joinNumber(party.getMemberParties().size() + 1)
+                .status(party.getStatus().toString())
+                .hashtags(party.getHashtags().stream().map(h -> h.getContent()).collect(Collectors.toList()))
+                .place(party.getPlace().toString())
+                .build();
+    }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyListResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyListResponseDto.java
@@ -2,22 +2,24 @@ package nbbang.com.nbbang.domain.party.dto;
 
 import lombok.Builder;
 import lombok.Data;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
+import nbbang.com.nbbang.domain.party.domain.Party;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data @Builder
 public class PartyListResponseDto {
     List<PartyFindResponseDto> parties;
 
-    public static PartyListResponseDto createMock() {
-        List<String> hashtags = Arrays.asList("BHC", "치킨");
-        PartyFindResponseDto partyFindResponseDto = new PartyFindResponseDto("연희동 올리브영 앞 BHC 7시", LocalDateTime.now(), 3, 4, "마감 임박", hashtags);
-        List<PartyFindResponseDto> collect = Arrays.asList(partyFindResponseDto);
+    public static PartyListResponseDto createFromEntity(List<Party> partyList) {
         return PartyListResponseDto.builder()
-                .parties(collect)
+                .parties(partyList.stream().map(PartyFindResponseDto::createByEntity).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static PartyListResponseDto createMock() {
+        return PartyListResponseDto.builder()
+                .parties(Arrays.asList(PartyFindResponseDto.createMock()))
                 .build();
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyReadResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyReadResponseDto.java
@@ -3,6 +3,7 @@ package nbbang.com.nbbang.domain.party.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import nbbang.com.nbbang.domain.member.dto.MemberResponseDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,7 +19,11 @@ public class PartyReadResponseDto {
     private Integer joinNumber;
     private Integer goalNumber;
     private String status;
-    private String nickname;
+    private String owner;
+    //private MemberResponseDto owner;
+    //private Boolean liked = false;
+    //private Boolean isOwner = false;
+    //private Boolean isMember = false;
     private Integer breadNumber;
     private List<String> hashtags;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/PartyRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/PartyRepository.java
@@ -1,7 +1,13 @@
 package nbbang.com.nbbang.domain.party.repository;
 
 import nbbang.com.nbbang.domain.party.domain.Party;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PartyRepository extends JpaRepository<Party, Long> {
+    Page<Party> findAll(Pageable pageable);
+
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -1,4 +1,19 @@
 package nbbang.com.nbbang.domain.party.service;
 
+import lombok.RequiredArgsConstructor;
+import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.repository.PartyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class PartyService {
+    private final PartyRepository partyRepository;
+
+    public Page<Party> findAll(Pageable pageable) {
+        return partyRepository.findAll(pageable);
+    }
+
 }

--- a/src/main/java/nbbang/com/nbbang/global/dto/PageableDto.java
+++ b/src/main/java/nbbang/com/nbbang/global/dto/PageableDto.java
@@ -1,0 +1,18 @@
+package nbbang.com.nbbang.global.dto;
+
+import org.springframework.data.domain.PageRequest;
+
+public abstract class PageableDto {
+    private Integer pageNumber;
+    private Integer pageSize;
+
+    public PageRequest createPageRequest() {
+        if (pageNumber == null) {
+            pageNumber = 0;
+        }
+        if (pageSize == null) {
+            pageSize = 10;
+        }
+        return PageRequest.of(pageNumber, pageSize);
+    }
+}

--- a/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
@@ -1,0 +1,89 @@
+package nbbang.com.nbbang.global.support.test;
+
+import nbbang.com.nbbang.domain.bbangpan.domain.MemberParty;
+import nbbang.com.nbbang.domain.bbangpan.repository.MemberPartyRepository;
+import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.dto.Place;
+import nbbang.com.nbbang.domain.member.repository.MemberRepository;
+import nbbang.com.nbbang.domain.party.domain.Hashtag;
+import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.domain.PartyStatus;
+import nbbang.com.nbbang.domain.party.repository.HashtagRepository;
+import nbbang.com.nbbang.domain.party.repository.PartyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+@Component
+@Transactional
+public class MockDataCreator implements CommandLineRunner {
+
+    @PersistenceContext EntityManager em;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired HashtagRepository hashtagRepository;
+    @Autowired MemberPartyRepository memberPartyRepository;
+
+    private Long luffyId;
+    private Long korungId;
+
+    private Long partyId;
+
+    @Override
+    public void run(String... args) throws Exception {
+        createMembers();
+        createParties();
+        createParties();
+    }
+
+    @Transactional
+    public void createMembers() {
+        Member luffy = Member.builder()
+                .nickname("루피")
+                .avatar("https://w.namu.la/s/bbff81cb4fd4d3f97d245a28a360b5cb665745b2cb434287f9cbd3423978919ce5377ef034f150277564c1798660ae95825fe2bfda50baa970f97d999a81c31401c0eb130e3bae0f9e1a2d3aea2a10769e564b0fbce08a8f23360382fd6e5425")
+                .place(Place.SINCHON)
+                .build();
+        memberRepository.save(luffy);
+        luffyId = luffy.getId();
+
+        Member korung = Member.builder()
+                .nickname("코렁")
+                .avatar("https://w.namu.la/s/bc75175b063a43a123523fba625ed9d185f6a180a3c1e9ae9409db0c110266e4f69e7aa434253687819b7dd5b36cccf4bd508977f6f76e3b9353db545d75168bfde624ca06dbf51818304d0bddc8c11cd1bdea60c7fb56113091172d05dd2dd5")
+                .place(Place.SINCHON)
+                .build();
+        memberRepository.save(korung);
+        korungId = korung.getId();
+    }
+
+    @Transactional
+    public void createParties() {
+        Party party = Party.builder()
+                .title("BHC 뿌링클 오늘 7시")
+                .content("오늘 연대 서문에서 치킨 같이 시켜 먹을 파티 구해요 또는 각자 시키고 배달비만 n빵 하실분?? 2~3명 모아봅니다 ㅎㅎ 뿌링클 교촌 다 좋아요 ㅎㅎ")
+                .createTime(LocalDateTime.of(2022, 02, 12, 12, 40))
+                .cancelTime(LocalDateTime.of(2022, 02, 13, 12, 40))
+                .goalNumber(4)
+                .owner(memberRepository.findById(luffyId).get())
+                .hashtags(Arrays.asList(Hashtag.builder().content("콤보").build(), Hashtag.builder().content("배달비").build(),Hashtag.builder().content("야식").build(),Hashtag.builder().content("사이드 가능").build()))
+                .place(Place.SINCHON)
+                .deliveryFee(300)
+                .status(PartyStatus.ON)
+                .isBlocked(false)
+                .build();
+        partyRepository.save(party);
+        partyId = party.getId();
+        hashtagRepository.save(Hashtag.builder().content("콤보").party(party).build());
+        memberPartyRepository.save(MemberParty.builder()
+                .member(memberRepository.findById(korungId).get())
+                .party(party)
+                .price(1000)
+                .build());
+    }
+
+}

--- a/src/main/java/nbbang/com/nbbang/global/support/validation/ValueOfEnum.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/validation/ValueOfEnum.java
@@ -1,0 +1,36 @@
+package nbbang.com.nbbang.global.support.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Validations for Enum Types
+ * 5. Validating That a String Matches a Value of an Enum
+ * Instead of validating an enum to match a String, we could also do the opposite. For this, we can create an annotation that checks if the String is valid for a specific enum
+ *
+ * This annotation can be added to a String field and we can pass any enum class.
+ *
+ * @ValueOfEnum(enumClass = CustomerType.class)
+ * private String customerTypeString;
+ *
+ * Reference: https://www.baeldung.com/javax-validations-enums
+ */
+
+
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = ValueOfEnumValidator.class)
+public @interface ValueOfEnum {
+    Class<? extends Enum<?>> enumClass();
+    String message() default "must be any of enum {enumClass}";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/nbbang/com/nbbang/global/support/validation/ValueOfEnumValidator.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/validation/ValueOfEnumValidator.java
@@ -1,0 +1,28 @@
+package nbbang.com.nbbang.global.support.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ValueOfEnumValidator implements ConstraintValidator<ValueOfEnum, CharSequence> {
+    private List<String> acceptedValues;
+
+    @Override
+    public void initialize(ValueOfEnum annotation) {
+        acceptedValues = Stream.of(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return acceptedValues.contains(value.toString());
+    }
+}


### PR DESCRIPTION
파티 리스트 조회 기능 구현, 페이징만 적용, 어플리케이션 실행 후 테스트 데이터 생성 기능 추가
필터나 검색 기능은 querydsl 로 구현하는게 편할 것 같아서 아직 보류했습니다. 