### PR TITLE
파티 리스트 조회 필터 기능 구현, QueryDsl, JUnit test 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.5.7'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'com.querydsl:querydsl-jpa'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
+	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.5.7'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/nbbang/com/nbbang/domain/member/service/MemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/service/MemberService.java
@@ -1,4 +1,7 @@
 package nbbang.com.nbbang.domain.member.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class MemberService {
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/service/MemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package nbbang.com.nbbang.domain.member.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class MemberService {
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
@@ -4,57 +4,33 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
-import nbbang.com.nbbang.domain.party.dto.PartyFindResponseDto;
 import nbbang.com.nbbang.domain.party.dto.PartyListResponseDto;
-import nbbang.com.nbbang.domain.party.service.PartyService;
+import nbbang.com.nbbang.domain.party.service.ManyPartyService;
 import nbbang.com.nbbang.global.response.*;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.springframework.http.HttpStatus.*;
 
 @Tag(name = "parties", description = "여러 개 파티 조회")
 @RestController
-@ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
-        @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json")),
-        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json"))
-})
+@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json"))
+@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json"))
 @Slf4j
 @RequiredArgsConstructor
 public class ManyPartyController {
 
-    private final PartyService partyService;
+    private final ManyPartyService manyPartyService;
 
     @Operation(summary = "여러 개 파티 리스트 조회", description = "여러 개의 파티 리스트를 전송합니다. json이 아닌 query parameter로 데이터를 전송해야 합니다.")
-    @ApiResponse(responseCode = "200", description = "OK",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
     @GetMapping("/parties")
     public ResponseEntity findParty(@ModelAttribute PartyFindRequestDto partyFindRequestDto) {
-        // @Validated, BindingResult bindingResult 넣어주기
-        // log.info("errors={}", bindingResult);
-/*        List<String> hashtags = Arrays.asList("BHC", "치킨");
-        PartyFindResponseDto partyFindResponseDto = new PartyFindResponseDto("연희동 올리브영 앞 BHC 7시", LocalDateTime.now(), 3, 4, "마감 임박", hashtags);
-        List<PartyFindResponseDto> collect = Arrays.asList(partyFindResponseDto);*/
-/*        System.out.println("partyFindRequestDto.getPlaces().size() = " + partyFindRequestDto.getPlaces().size());
-        partyFindRequestDto.getPlaces().stream().forEach(System.out::println);
-        System.out.println("partyFindRequestDto.isOngoing() "+ partyFindRequestDto.isOngoing());*/
-
-        Page<Party> resultEntities = partyService.findAll(partyFindRequestDto.createPageRequest());
-        PartyListResponseDto resultDto = PartyListResponseDto.createFromEntity(resultEntities.getContent());
-        //PartyListResponseDto resultDto = PartyListResponseDto.createMock();
-        return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessageParty.PARTY_FIND_SUCCESS, resultDto), OK);
+        return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessageParty.PARTY_FIND_SUCCESS,
+                PartyListResponseDto.createFromEntity(manyPartyService.findAllByRequestDto(partyFindRequestDto).getContent())),OK);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
@@ -34,7 +34,7 @@ public class ManyPartyController {
     @GetMapping("/parties")
     public ResponseEntity findParty(@ModelAttribute PartyFindRequestDto partyFindRequestDto) {
         Page<Party> queryResults = manyPartyService.findAllByRequestDto(partyFindRequestDto.createPageRequest(),
-                PartyFindRequestFilterDto.createRequestFilterDto(partyFindRequestDto.getSearch()));
+                PartyFindRequestFilterDto.createRequestFilterDto(partyFindRequestDto.getShowOngoing(), partyFindRequestDto.getSearch()));
         return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessageParty.PARTY_FIND_SUCCESS,
                 PartyListResponseDto.createFromEntity(queryResults.getContent())), OK);
     }

--- a/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/controller/ManyPartyController.java
@@ -7,10 +7,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import nbbang.com.nbbang.domain.party.dto.PartyListResponseDto;
 import nbbang.com.nbbang.domain.party.service.ManyPartyService;
 import nbbang.com.nbbang.global.response.*;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,7 +33,9 @@ public class ManyPartyController {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
     @GetMapping("/parties")
     public ResponseEntity findParty(@ModelAttribute PartyFindRequestDto partyFindRequestDto) {
+        Page<Party> queryResults = manyPartyService.findAllByRequestDto(partyFindRequestDto.createPageRequest(),
+                PartyFindRequestFilterDto.createRequestFilterDto(partyFindRequestDto.getSearch()));
         return new ResponseEntity(DefaultResponse.res(StatusCode.OK, ResponseMessageParty.PARTY_FIND_SUCCESS,
-                PartyListResponseDto.createFromEntity(manyPartyService.findAllByRequestDto(partyFindRequestDto).getContent())),OK);
+                PartyListResponseDto.createFromEntity(queryResults.getContent())), OK);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestDto.java
@@ -13,6 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 public class PartyFindRequestDto extends PageableDto {
     private List<String> places;
-    private Boolean isOngoing;
+    private Boolean showOngoing;
     private String search;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestFilterDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestFilterDto.java
@@ -13,11 +13,19 @@ import java.awt.print.Pageable;
 @Data @Builder
 public class PartyFindRequestFilterDto {
 
+    private Boolean showOngoing = false;
     private String search;
 
     public static PartyFindRequestFilterDto createRequestFilterDto(String search) {
         return PartyFindRequestFilterDto.builder()
                 .search(search)
+                .build();
+    }
+
+    public static PartyFindRequestFilterDto createRequestFilterDto(Boolean showOngoing, String search) {
+        return PartyFindRequestFilterDto.builder()
+                .search(search)
+                .showOngoing(showOngoing)
                 .build();
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestFilterDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindRequestFilterDto.java
@@ -1,0 +1,29 @@
+package nbbang.com.nbbang.domain.party.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import nbbang.com.nbbang.global.dto.PageableDto;
+
+import java.awt.print.Pageable;
+
+/**
+ * Service layer 에 필터를 적용한 파티리스트 조회하기 위한 dto 입니다.
+ */
+
+@Data @Builder
+public class PartyFindRequestFilterDto {
+
+    private String search;
+
+    public static PartyFindRequestFilterDto createRequestFilterDto(String search) {
+        return PartyFindRequestFilterDto.builder()
+                .search(search)
+                .build();
+    }
+
+    public static PartyFindRequestFilterDto createRequestFilterDto(PartyFindRequestDto requestDto) {
+        return PartyFindRequestFilterDto.builder()
+                .search(requestDto.getSearch())
+                .build();
+    }
+}

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/PartyFindResponseDto.java
@@ -42,7 +42,7 @@ public class PartyFindResponseDto{
                 .goalNumber(party.getGoalNumber())
                 .joinNumber(party.getMemberParties().size() + 1)
                 .status(party.getStatus().toString())
-                .hashtags(party.getHashtags().stream().map(h -> h.getContent()).collect(Collectors.toList()))
+                //.hashtags(party.getHashtags().stream().map(h -> h.getContent()).collect(Collectors.toList()))
                 .place(party.getPlace().toString())
                 .build();
     }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepository.java
@@ -2,6 +2,7 @@ package nbbang.com.nbbang.domain.party.repository;
 
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,5 @@ public interface ManyPartyRepository extends JpaRepository<Party, Long>, ManyPar
     Page<Party> findAll(Pageable pageable);
 
     @Override
-    Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto);
+    Page<Party> findAllByRequestDto(Pageable pageable, PartyFindRequestFilterDto requestFilterDto);
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupport.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupport.java
@@ -2,8 +2,10 @@ package nbbang.com.nbbang.domain.party.repository;
 
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ManyPartyRepositorySupport {
-    Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto);
+    Page<Party> findAllByRequestDto(Pageable pageable, PartyFindRequestFilterDto requestFilterDto);
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupport.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupport.java
@@ -3,14 +3,7 @@ package nbbang.com.nbbang.domain.party.repository;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-
-public interface ManyPartyRepository extends JpaRepository<Party, Long>, ManyPartyRepositorySupport {
-
-    Page<Party> findAll(Pageable pageable);
-
-    @Override
+public interface ManyPartyRepositorySupport {
     Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto);
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
@@ -1,0 +1,14 @@
+package nbbang.com.nbbang.domain.party.repository;
+
+import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
+import org.springframework.data.domain.Page;
+
+public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySupport {
+
+
+    @Override
+    public Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto) {
+        return null;
+    }
+}

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
@@ -2,13 +2,15 @@ package nbbang.com.nbbang.domain.party.repository;
 
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySupport {
 
 
     @Override
-    public Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto) {
+    public Page<Party> findAllByRequestDto(Pageable pageable, PartyFindRequestFilterDto requestFilterDto) {
         return null;
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
@@ -1,13 +1,16 @@
 package nbbang.com.nbbang.domain.party.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
 import nbbang.com.nbbang.domain.party.domain.Party;
-import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+@RequiredArgsConstructor
 public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySupport {
 
+    private final JPAQueryFactory query;
 
     @Override
     public Page<Party> findAllByRequestDto(Pageable pageable, PartyFindRequestFilterDto requestFilterDto) {

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
@@ -1,11 +1,17 @@
 package nbbang.com.nbbang.domain.party.repository;
 
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.domain.PartyStatus;
+import nbbang.com.nbbang.domain.party.domain.QParty;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySupport {
@@ -14,6 +20,19 @@ public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySuppor
 
     @Override
     public Page<Party> findAllByRequestDto(Pageable pageable, PartyFindRequestFilterDto requestFilterDto) {
-        return null;
+        System.out.println("===========-=-=-=-=-=-=ㅇㅅㅇ=-=-=-=====================");
+        QParty party = QParty.party;
+        JPQLQuery<Party> q = query.selectFrom(party)
+                .where(party.title.contains(requestFilterDto.getSearch()));
+        System.out.println(requestFilterDto.getShowOngoing());
+        if (requestFilterDto.getShowOngoing()) {
+            q.where(party.status.eq(PartyStatus.ON));
+        }
+        q.offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+        List<Party> res = q.fetch();
+        Long count = query.selectFrom(party)
+                .stream().count();
+        return new PageImpl<>(res, pageable, count);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/PartyRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/PartyRepository.java
@@ -9,5 +9,4 @@ import org.springframework.stereotype.Repository;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
     Page<Party> findAll(Pageable pageable);
-
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/ManyPartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/ManyPartyService.java
@@ -2,6 +2,7 @@ package nbbang.com.nbbang.domain.party.service;
 
 import lombok.RequiredArgsConstructor;
 import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
 import nbbang.com.nbbang.domain.party.repository.ManyPartyRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ManyPartyService {
     private final ManyPartyRepository manyPartyRepository;
 
-    public Page<Party> findAll(Pageable pageable) {
-        return manyPartyRepository.findAll(pageable);
+    public Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto) {
+        return manyPartyRepository.findAllByRequestDto(requestDto);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/ManyPartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/ManyPartyService.java
@@ -3,6 +3,7 @@ package nbbang.com.nbbang.domain.party.service;
 import lombok.RequiredArgsConstructor;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.PartyFindRequestDto;
+import nbbang.com.nbbang.domain.party.dto.PartyFindRequestFilterDto;
 import nbbang.com.nbbang.domain.party.repository.ManyPartyRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ManyPartyService {
     private final ManyPartyRepository manyPartyRepository;
 
-    public Page<Party> findAllByRequestDto(PartyFindRequestDto requestDto) {
-        return manyPartyRepository.findAllByRequestDto(requestDto);
+    public Page<Party> findAllByRequestDto(Pageable pageable, PartyFindRequestFilterDto requestFilterDto) {
+        return manyPartyRepository.findAllByRequestDto(pageable, requestFilterDto);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/global/config/QueryDslConfig.java
+++ b/src/main/java/nbbang/com/nbbang/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package nbbang.com.nbbang.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() { return new JPAQueryFactory(em); }
+
+}

--- a/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
@@ -70,7 +70,7 @@ public class MockDataCreator implements CommandLineRunner {
                 .cancelTime(LocalDateTime.of(2022, 02, 13, 12, 40))
                 .goalNumber(4)
                 .owner(memberRepository.findById(luffyId).get())
-                .hashtags(Arrays.asList(Hashtag.builder().content("콤보").build(), Hashtag.builder().content("배달비").build(),Hashtag.builder().content("야식").build(),Hashtag.builder().content("사이드 가능").build()))
+                //.hashtags(Arrays.asList(Hashtag.builder().content("콤보").build(), Hashtag.builder().content("배달비").build(),Hashtag.builder().content("야식").build(),Hashtag.builder().content("사이드 가능").build()))
                 .place(Place.SINCHON)
                 .deliveryFee(300)
                 .status(PartyStatus.ON)
@@ -78,7 +78,7 @@ public class MockDataCreator implements CommandLineRunner {
                 .build();
         partyRepository.save(party);
         partyId = party.getId();
-        hashtagRepository.save(Hashtag.builder().content("콤보").party(party).build());
+        //hashtagRepository.save(Hashtag.builder().content("콤보").party(party).build());
         memberPartyRepository.save(MemberParty.builder()
                 .member(memberRepository.findById(korungId).get())
                 .party(party)

--- a/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
@@ -12,6 +12,7 @@ import nbbang.com.nbbang.domain.party.repository.HashtagRepository;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,7 @@ import java.util.Arrays;
 
 @Component
 @Transactional
+@Profile("!test")
 public class MockDataCreator implements CommandLineRunner {
 
     @PersistenceContext EntityManager em;

--- a/src/test/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositoryTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositoryTest.java
@@ -1,0 +1,16 @@
+package nbbang.com.nbbang.domain.party.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ManyPartyRepositoryTest {
+    @Test
+    public void filterTest() {
+
+    }
+}

--- a/src/test/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositoryTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositoryTest.java
@@ -1,6 +1,9 @@
 package nbbang.com.nbbang.domain.party.repository;
 
+import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.service.PartyService;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -9,6 +12,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @ActiveProfiles("test")
 class ManyPartyRepositoryTest {
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyService partyService;
+
     @Test
     public void filterTest() {
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.SQL=debug


### PR DESCRIPTION
- 파티 리스트 조회를 제목 검색어와 status 가 ON 인지로 필터를 적용할 수 있습니다.
- QueryDsl 환경 설정을 추가하였습니다.
- 테스트 환경 설정을 추가하였습니다.