### PR TITLE
채팅 읽음 처리 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.projectlombok:lombok:1.18.20'
+	implementation 'org.projectlombok:lombok:1.18.20'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
@@ -33,10 +33,11 @@ public class PartyMember {
 
     protected PartyMember() {}
 
-    public static PartyMember createMemberParty(Member member, Party party) {
+    public static PartyMember createMemberParty(Member member, Party party, Message lastReadMessage) {
         PartyMember partyMember = PartyMember.builder()
                 .member(member)
                 .party(party)
+                .lastReadMessage(lastReadMessage)
                 .build();
         party.getPartyMembers().add(partyMember);
         return partyMember;

--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
@@ -3,6 +3,7 @@ package nbbang.com.nbbang.domain.bbangpan.domain;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.party.domain.Party;
 
@@ -11,12 +12,16 @@ import javax.persistence.*;
 @Entity @Getter @Builder
 @AllArgsConstructor
 public class PartyMember {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue
     private Long id;
 
     private Integer price;
 
     private String sendStatus;
+
+    @OneToOne
+    @JoinColumn(name = "message_id")
+    private Message lastReadMessage;
 
     @ManyToOne
     @JoinColumn(name = "member_id")
@@ -35,5 +40,9 @@ public class PartyMember {
                 .build();
         party.getPartyMembers().add(partyMember);
         return partyMember;
+    }
+
+    public void changeLastReadMessage(Message message) {
+        this.lastReadMessage = message;
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
@@ -51,7 +51,7 @@ public class ChatRoomController {
         if (pageSize == null) {
             pageSize = 10;
         }
-        Party party = partyRepository.findById(partyId).get(); // Party Service 구현 시 바꿔야 할 것 같습니다.
+        Party party = partyService.findById(partyId);
         Page<Message> messages = chatService.findMessages(party, PageRequest.of(0, pageSize));
         return DefaultResponse.res(StatusCode.OK, ChatResponseMessage.READ_CHAT, ChatResponseDto.createByPartyAndMessagesEntity(party, messages.getContent(), currentMember.id()));
     }
@@ -62,7 +62,7 @@ public class ChatRoomController {
     @ApiResponse(responseCode = "403", description = "Not Party Member", content = @Content(mediaType = "application/json"))
     @GetMapping("/{party-id}/messages")
     public DefaultResponse selectChatMessages(@PathVariable("party-id") Long partyId, @ParameterObject PageableDto pageableDto, @RequestParam(required = false) Long cursorId) {
-        readMessage(partyId,1L); // 채팅방에 들어오면 읽음을 처리합니다. 위치를 수정해도 될 것 같습니다.
+        readMessage(partyId,currentMember.id()); // 채팅방에 들어오면 읽음을 처리합니다. 위치를 수정해도 될 것 같습니다.
         Party party = partyService.findById(partyId);
         if (cursorId == null) {
             cursorId = chatService.findLastMessage(party).getId();

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
@@ -71,7 +71,7 @@ public class ChatRoomController {
         return DefaultResponse.res(StatusCode.OK, ChatResponseMessage.READ_CHAT, ChatSendListResponseDto.createByEntity(messages.getContent(), currentMember.id()));
     }
     public void readMessage(Long partyId, Long memberId){
-        Long lastReadMessageId = chatService.readMessage(memberId, partyId);
+        Long lastReadMessageId = chatService.readMessage(partyId, memberId);
         ChatReadSocketDto chatReadSocketDto = ChatReadSocketDto.builder().lastReadMessageId(lastReadMessageId).build();
         simpMessagingTemplate.convertAndSend("/topic/" + partyId, chatReadSocketDto);
         log.info("[Socket] lastReadMessageId: {}, partyId: {}", lastReadMessageId, partyId);
@@ -83,7 +83,7 @@ public class ChatRoomController {
     @ApiResponse(responseCode = "403", description = "Not Party Member", content = @Content(mediaType = "application/json"))
     @PostMapping("/{party-id}/out")
     public DefaultResponse exitChat(@PathVariable("party-id") Long partyId) {
-        chatService.exitChat(partyId, 1L);
+        chatService.exitChatRoom(partyId, 1L);
         return DefaultResponse.res(StatusCode.OK, ChatResponseMessage.EXIT_CHAT);
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
@@ -62,12 +62,12 @@ public class ChatRoomController {
     @ApiResponse(responseCode = "403", description = "Not Party Member", content = @Content(mediaType = "application/json"))
     @GetMapping("/{party-id}/messages")
     public DefaultResponse selectChatMessages(@PathVariable("party-id") Long partyId, @ParameterObject PageableDto pageableDto, @RequestParam(required = false) Long cursorId) {
+        readMessage(partyId,1L); // 채팅방에 들어오면 읽음을 처리합니다. 위치를 수정해도 될 것 같습니다.
         Party party = partyService.findById(partyId);
         if (cursorId == null) {
             cursorId = chatService.findLastMessage(party).getId();
         }
         Page<Message> messages = chatService.findMessagesByCursorId(party, pageableDto.createPageRequest(), cursorId);
-        readMessage(partyId,1L); // 채팅방에서 들어오는 api가 없어서 여기 넣어둡니다.
         return DefaultResponse.res(StatusCode.OK, ChatResponseMessage.READ_CHAT, ChatSendListResponseDto.createByEntity(messages.getContent(), currentMember.id()));
     }
     public void readMessage(Long partyId, Long memberId){
@@ -113,7 +113,7 @@ public class ChatRoomController {
     @ApiResponse(responseCode = "403", description = "Not Party Member", content = @Content(mediaType = "application/json"))
     @GetMapping("/{party-id}/messages/develop")
     public DefaultResponse selectChatMessagesWithCookie(@PathVariable("party-id") Long partyId, @ParameterObject PageableDto pageableDto, HttpServletRequest request, @CookieValue(value = "cursorId", required = false) Cookie cookie) {
-        Party party = partyService.findById(partyId); // Party Service 구현 시 바꿔야 할 것 같습니다.
+        Party party = partyService.findById(partyId);
         String [] cookieVals = cookie.getValue().split("=");
         Long cookiePartyId = Long.parseLong(cookieVals[0]);
         Long cursorId = Long.parseLong(cookieVals[1]);

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
@@ -77,13 +77,12 @@ public class ChatRoomController {
         log.info("[Socket] lastReadMessageId: {}, partyId: {}", lastReadMessageId, partyId);
     }
 
-    @Operation(summary = "채팅방에서 나가기", description = "채팅방에서 나갑니다. 소켓 종료 용도로 쓰일 것 같습니다.")
+    @Operation(summary = "채팅방에서 나가기", description = "채팅방에서 나갑니다. 소켓 종료 용도로 쓰일 것 같습니다. ")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json"))
     @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content(mediaType = "application/json"))
     @ApiResponse(responseCode = "403", description = "Not Party Member", content = @Content(mediaType = "application/json"))
     @PostMapping("/{party-id}/out")
     public DefaultResponse exitChat(@PathVariable("party-id") Long partyId) {
-        chatService.exitChatRoom(partyId, 1L);
         return DefaultResponse.res(StatusCode.OK, ChatResponseMessage.EXIT_CHAT);
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatSocketAPI.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatSocketAPI.java
@@ -10,23 +10,27 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import nbbang.com.nbbang.domain.chat.dto.ChatReadSocketDto;
 import nbbang.com.nbbang.domain.chat.dto.message.ChatSendResponseDto;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.lang.reflect.Modifier;
 
 import static java.lang.reflect.Modifier.PRIVATE;
 
-@Tag(name = "ChatSocket", description = "채팅방의 소켓 관련된 API입니다.")
-@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json"))
+@Tag(name = "ChatSocketDevelop", description = "채팅방의 소켓 관련된 API입니다.")
 @NoArgsConstructor(access = AccessLevel.PRIVATE) // ONLY FOR SWAGGER. Don't do anything for Logic.
+@RestController
 public class ChatSocketAPI {
 
     @Operation(summary = "[Socket] 채팅 메시지 전송", description = "다른 사람이 채팅 메시지를 전송하면, 채팅방 내의 유저들이 받는 소켓입니다.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChatSendResponseDto.class)))
+    @PostMapping("/chat/develop")
     public void socketEmitApi(Long memberId, Long partyId){
     }
 
-    @Operation(summary = "[Socket] 채팅 읽음", description = "다른 사람이 채팅방에 들어와 메시지를 읽으면, 채팅방 내의 유저들이 받는 소켓입니다. lastReadMessageId 이후의 messageId는 전부 읽은 사람 수를 -1 해주세요.")
+    @Operation(summary = "[Socket] 채팅 읽음", description = "다른 사람이 채팅방에 들어와 메시지를 읽으면, 채팅방 내의 유저들이 받는 소켓입니다. lastReadMessageId보다 큰 id를 갖는 메시지들은 전부 읽지 않은 사람 수를 -1 해주세요.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChatReadSocketDto.class)))
+    @PostMapping("/chat/develop/read")
     public void readMessage(Long memberId, Long partyId){
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatSocketAPI.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatSocketAPI.java
@@ -1,0 +1,32 @@
+package nbbang.com.nbbang.domain.chat.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import nbbang.com.nbbang.domain.chat.dto.ChatReadSocketDto;
+import nbbang.com.nbbang.domain.chat.dto.message.ChatSendResponseDto;
+
+import java.lang.reflect.Modifier;
+
+import static java.lang.reflect.Modifier.PRIVATE;
+
+@Tag(name = "ChatSocket", description = "채팅방의 소켓 관련된 API입니다.")
+@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json"))
+@NoArgsConstructor(access = AccessLevel.PRIVATE) // ONLY FOR SWAGGER. Don't do anything for Logic.
+public class ChatSocketAPI {
+
+    @Operation(summary = "[Socket] 채팅 메시지 전송", description = "다른 사람이 채팅 메시지를 전송하면, 채팅방 내의 유저들이 받는 소켓입니다.")
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChatSendResponseDto.class)))
+    public void socketEmitApi(Long memberId, Long partyId){
+    }
+
+    @Operation(summary = "[Socket] 채팅 읽음", description = "다른 사람이 채팅방에 들어와 메시지를 읽으면, 채팅방 내의 유저들이 받는 소켓입니다. lastReadMessageId 이후의 messageId는 전부 읽은 사람 수를 -1 해주세요.")
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChatReadSocketDto.class)))
+    public void readMessage(Long memberId, Long partyId){
+    }
+}

--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/MessageController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/MessageController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.chat.dto.ChatMessageImageUploadResponseDto;
+import nbbang.com.nbbang.domain.chat.dto.ChatReadSocketDto;
 import nbbang.com.nbbang.domain.chat.dto.message.ChatSendRequestDto;
 import nbbang.com.nbbang.domain.chat.dto.message.ChatSendResponseDto;
 import nbbang.com.nbbang.domain.chat.service.MessageService;

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatReadSocketDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ChatReadSocketDto.java
@@ -1,0 +1,11 @@
+package nbbang.com.nbbang.domain.chat.dto;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChatReadSocketDto {
+    private Long lastReadMessageId;
+}

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
@@ -22,4 +22,5 @@ public interface MessageRepository extends JpaRepository<Message, Long>, Message
     @Query(value="update Message m set m.read_number = m.read_number + 1 " +
             "where m.message_id > :lastReadId and m.party_id = :partyId", nativeQuery=true)
     int bulkReadNumberPlus(@Param("lastReadId") Long lastReadId, @Param("partyId") Long partyId);
+
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
@@ -5,6 +5,9 @@ import nbbang.com.nbbang.domain.party.domain.Party;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositorySupport {
 
@@ -14,4 +17,9 @@ public interface MessageRepository extends JpaRepository<Message, Long>, Message
     Page<Message> findAllByCursorId(Long partyId, Pageable pageable, Long cursorId);
 
     Long countByPartyId(Long partyId);
+
+
+    @Modifying
+    @Query(value="update Message m set m.readNumber = m.readNumber + 1 where m.id > :lastReadId and m.party_id = :partyId", nativeQuery=true)
+    int bulkReadNumberPlus(@Param("lastReadId") Long lastReadId, @Param("partyId") Long partyId);
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
@@ -18,8 +18,8 @@ public interface MessageRepository extends JpaRepository<Message, Long>, Message
 
     Long countByPartyId(Long partyId);
 
-
-    @Modifying
-    @Query(value="update Message m set m.readNumber = m.readNumber + 1 where m.id > :lastReadId and m.party_id = :partyId", nativeQuery=true)
+    @Modifying(clearAutomatically = true)
+    @Query(value="update Message m set m.read_number = m.read_number + 1 " +
+            "where m.message_id > :lastReadId and m.party_id = :partyId", nativeQuery=true)
     int bulkReadNumberPlus(@Param("lastReadId") Long lastReadId, @Param("partyId") Long partyId);
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package nbbang.com.nbbang.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
+import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
@@ -10,6 +11,7 @@ import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.domain.PartyStatus;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
+import nbbang.com.nbbang.domain.party.service.PartyService;
 import nbbang.com.nbbang.global.error.exception.NotPartyMemberException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +29,9 @@ public class ChatService {
     private final MessageRepository messageRepository;
     private final MemberService memberService;
     private final PartyRepository partyRepository;
+    private final PartyService partyService;
+    private final PartyMemberRepository partyMemberRepository;
+    private final MessageService messageService;
 
     /*public Long findLastMessageId(Long partyId) {
         return messageRepository.findLastMessageId(partyId);
@@ -141,4 +146,13 @@ public class ChatService {
         return message.getId();
     }
 
+    @Transactional
+    public Long readMessage(Long memberId, Long partyId) {
+        Party party = partyService.findById(partyId);
+        PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
+        Long lastReadMessageId = partyMember.getLastReadMessage().getId();
+        Message message = messageService.findLastMessageAndUpdateReadNumber(partyId);
+        partyMember.changeLastReadMessage(message);
+        return lastReadMessageId;
+    }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -36,7 +36,6 @@ public class ChatService {
     private final PartyRepository partyRepository;
     private final PartyService partyService;
     private final PartyMemberRepository partyMemberRepository;
-    private final MessageService messageService;
 
     /*public Long findLastMessageId(Long partyId) {
         return messageRepository.findLastMessageId(partyId);
@@ -147,21 +146,21 @@ public class ChatService {
     }
 
     @Transactional
-    public Long readMessageForEnterChat(Long memberId, Long partyId) {
+    public Long readMessage(Long partyId, Long memberId) {
+        log.info("*****************");
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
+        log.info("partyMemberId: {}", partyMember.getId());
+        log.info("*****************");
         Long lastReadMessageId = (Optional.ofNullable(partyMember.getLastReadMessage()).orElse(Message.builder().id(-1L).build())).getId();
         messageRepository.bulkReadNumberPlus(lastReadMessageId, partyId);
-        Message currentlastMessage = partyService.findLastMessage(partyId);
-        partyMember.changeLastReadMessage(currentlastMessage);
+        Message currentLastMessage = partyService.findLastMessage(partyId);
+        partyMember.changeLastReadMessage(currentLastMessage);
         return lastReadMessageId;
     }
 
-    @Transactional
-    public void readMessageForExitChat(Long memberId, Long partyId) {
+    public void exitChat(Long partyId, Long memberId) {
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
-        messageRepository.bulkReadNumberPlus(partyMember.getLastReadMessage().getId(), partyId);
-        Message lastMessage = partyService.findLastMessage(partyId);
-        partyMember.changeLastReadMessage(lastMessage);
+        Message currentLastMessage = partyService.findLastMessage(partyId);
+        partyMember.changeLastReadMessage(currentLastMessage);
     }
-
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -1,6 +1,7 @@
 package nbbang.com.nbbang.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage;
@@ -20,10 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class ChatService {
     // 최초 입장 시, 탈퇴시 메시지 보내는게 있어야함
     private final MessageRepository messageRepository;
@@ -149,8 +152,10 @@ public class ChatService {
     @Transactional
     public Long readMessage(Long memberId, Long partyId) {
         Party party = partyService.findById(partyId);
+        log.info("memberId: {}, partyId: {}", memberId, partyId);
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
-        Long lastReadMessageId = partyMember.getLastReadMessage().getId();
+
+        Long lastReadMessageId = (Optional.ofNullable(partyMember.getLastReadMessage()).orElse(Message.builder().id(-1L).build())).getId();
         Message message = messageService.findLastMessageAndUpdateReadNumber(partyId);
         partyMember.changeLastReadMessage(message);
         return lastReadMessageId;

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -6,7 +6,6 @@ import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage;
 import nbbang.com.nbbang.domain.chat.domain.Message;
-import nbbang.com.nbbang.domain.chat.dto.ChatReadSocketDto;
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
@@ -17,8 +16,6 @@ import nbbang.com.nbbang.domain.party.service.PartyService;
 import nbbang.com.nbbang.global.error.exception.NotPartyMemberException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
@@ -158,7 +155,7 @@ public class ChatService {
         return lastReadMessageId;
     }
 
-    public void exitChat(Long partyId, Long memberId) {
+    public void exitChatRoom(Long partyId, Long memberId) {
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
         Message currentLastMessage = partyService.findLastMessage(partyId);
         partyMember.changeLastReadMessage(currentLastMessage);

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatSessionService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatSessionService.java
@@ -22,10 +22,13 @@ public class ChatSessionService {
     }
 
     @Transactional
-    public Long deleteBySessionId(String sessionId) {
+    public Long deleteIfExistBySessionId(String sessionId) {
         ChatSession chatSession = chatSessionRepository.findBySessionId(sessionId);
-        chatSessionRepository.delete(chatSession);
-        Long partyId = chatSession.getParty().removeChatSession(chatSession);
+        Long partyId = -1L;
+        if(chatSession!=null){
+            chatSessionRepository.delete(chatSession);
+            partyId = chatSession.getParty().removeChatSession(chatSession);
+        }
         return partyId;
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
@@ -7,18 +7,10 @@ import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
-import nbbang.com.nbbang.domain.party.repository.PartyRepository;
 import nbbang.com.nbbang.domain.party.service.PartyService;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.webjars.NotFoundException;
-
-import javax.persistence.Column;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import java.time.LocalDateTime;
 
 import static nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage.MESSAGE_NOT_FOUND;
 
@@ -64,10 +56,16 @@ public class MessageService {
         return count;
     }
 
-
+    @Transactional
     public Message findLastMessageAndUpdateReadNumber(Long partyId) {
         Message lastMessage = messageRepository.findLastMessage(partyId);
         messageRepository.bulkReadNumberPlus(lastMessage.getId(), partyId);
         return lastMessage;
     }
+
+    public Message findLastByPartyId(Long partyId) {
+        Message lastMessage = messageRepository.findLastMessage(partyId);
+        return lastMessage;
+    }
+
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
@@ -7,12 +7,14 @@ import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.repository.PartyRepository;
 import nbbang.com.nbbang.domain.party.service.PartyService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
 
 import static nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage.MESSAGE_NOT_FOUND;
+import static nbbang.com.nbbang.domain.party.controller.PartyResponseMessage.PARTY_NOT_FOUND;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -20,12 +22,12 @@ import static nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage.MESSA
 public class MessageService {
 
     private final MessageRepository messageRepository;
-    private final PartyService partyService;
+    private final PartyRepository partyRepository;
     private final MemberService memberService;
 
     @Transactional
     public Long send(Long partyId, Long senderId, String content) {
-        Party party = partyService.findById(partyId);
+        Party party = partyRepository.findById(partyId).orElseThrow(()->new NotFoundException(PARTY_NOT_FOUND));
         Member sender = memberService.findById(senderId);
         Long orderInChat = countByPartyId(partyId);
         Integer readNumber = party.getActiveNumber();
@@ -37,7 +39,7 @@ public class MessageService {
 
     @Transactional
     public Long send(Long partyId, Long senderId, String content, MessageType type) {
-        Party party = partyService.findById(partyId);
+        Party party = partyRepository.findById(partyId).orElseThrow(()->new NotFoundException(PARTY_NOT_FOUND));
         Member sender = memberService.findById(senderId);
         Long orderInChat = countByPartyId(partyId);
         Integer readNumber = party.getActiveNumber();

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
@@ -58,16 +58,4 @@ public class MessageService {
         return count;
     }
 
-    @Transactional
-    public Message findLastMessageAndUpdateReadNumber(Long partyId) {
-        Message lastMessage = messageRepository.findLastMessage(partyId);
-        messageRepository.bulkReadNumberPlus(lastMessage.getId(), partyId);
-        return lastMessage;
-    }
-
-    public Message findLastByPartyId(Long partyId) {
-        Message lastMessage = messageRepository.findLastMessage(partyId);
-        return lastMessage;
-    }
-
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
@@ -63,4 +63,11 @@ public class MessageService {
         Long count = messageRepository.countByPartyId(partyId);
         return count;
     }
+
+
+    public Message findLastMessageAndUpdateReadNumber(Long partyId) {
+        Message lastMessage = messageRepository.findLastMessage(partyId);
+        messageRepository.bulkReadNumberPlus(lastMessage.getId(), partyId);
+        return lastMessage;
+    }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/service/MemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/service/MemberService.java
@@ -1,11 +1,11 @@
 package nbbang.com.nbbang.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.member.controller.MemberResponseMessage;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.dto.Place;
 import nbbang.com.nbbang.domain.member.repository.MemberRepository;
-import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.global.FileUpload.S3Uploader;
 import nbbang.com.nbbang.global.security.Role;
 import org.springframework.stereotype.Service;
@@ -76,6 +76,5 @@ public class MemberService {
         Member member = findById(memberId);
         member.leaveMember();
     }
-
 
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/controller/PartyController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/controller/PartyController.java
@@ -20,21 +20,15 @@ import nbbang.com.nbbang.domain.party.dto.single.request.PartyStatusChangeReques
 import nbbang.com.nbbang.domain.party.dto.single.response.PartyIdResponseDto;
 import nbbang.com.nbbang.domain.party.dto.single.response.PartyReadResponseDto;
 import nbbang.com.nbbang.domain.party.service.PartyService;
-import nbbang.com.nbbang.global.error.ErrorResponse;
 import nbbang.com.nbbang.global.error.exception.CustomIllegalArgumentException;
 import nbbang.com.nbbang.global.interceptor.CurrentMember;
 import nbbang.com.nbbang.global.response.DefaultResponse;
 import nbbang.com.nbbang.global.error.GlobalErrorResponseMessage;
 import nbbang.com.nbbang.global.response.StatusCode;
-import org.springdoc.api.ErrorMessage;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,8 +58,8 @@ public class PartyController {
             throw new CustomIllegalArgumentException(GlobalErrorResponseMessage.ILLEGAL_ARGUMENT_ERROR, bindingResult);
         }
         Member member = memberService.findById(currentMember.id());
-        Party party = partyRequestDto.createByDtoWithMember(member);
-        Long partyId = partyService.create(party, partyRequestDto.getHashtags());
+        Party party = partyRequestDto.createEntityByDto();
+        Long partyId = partyService.create(party, currentMember.id(), partyRequestDto.getHashtags());
         return DefaultResponse.res(StatusCode.OK, PartyResponseMessage.PARTY_CREATE_SUCCESS, new PartyIdResponseDto(partyId));
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
@@ -91,6 +91,7 @@ public class Party {
     }
 
     public void addOwner(Member member) {
+
         this.owner = member;
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static javax.persistence.EnumType.STRING;
@@ -120,7 +121,7 @@ public class Party {
     }
 
     public void updateActiveNumber(Integer updateNumbder){
-        activeNumber +=updateNumbder;
+        activeNumber = Optional.ofNullable(activeNumber).orElse(0) + updateNumbder;
     }
 
     public Long removeChatSession(ChatSession chatSession) {

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/single/request/PartyRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/single/request/PartyRequestDto.java
@@ -44,25 +44,14 @@ public class PartyRequestDto {
     @Min(2) @Max(10)
     private Integer goalNumber;
 
-    public Party createByDto() {
-        Party party = Party.builder()
-                .title(this.title)
-                .content(this.content)
-                .place(Place.valueOf(place.toUpperCase()))
-                .goalNumber(this.goalNumber)
-                .activeNumber(0)
-                .build();
-        return party;
-    }
-
-    public Party createByDtoWithMember(Member owner) {
+    public Party createEntityByDto() {
         return Party.builder()
                 .title(this.title)
                 .content(this.content)
                 .place(Place.valueOf(place.toUpperCase()))
                 .goalNumber(this.goalNumber)
-                .owner(owner)
                 .createTime(LocalDateTime.now())
+                .activeNumber(0)
                 .build();
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
@@ -16,6 +16,8 @@ import nbbang.com.nbbang.global.error.exception.NotPartyMemberException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional(readOnly=true)
 @RequiredArgsConstructor
@@ -25,11 +27,9 @@ public class PartyMemberService {
     private final MessageService messageService;
 
     public boolean isPartyOwnerOrMember(Party party, Member member) {
-        log.info("ownerId: {}",party.getOwner().getId());
-        party.getPartyMembers().stream().forEach(m->log.info("memberId: {}", m.getId()));
-        log.info("******************");
-        return party.getOwner().equals(member) || party.getPartyMembers().stream().anyMatch(mp -> mp.getMember().equals(member));
+        return Optional.ofNullable(party.getOwner()).equals(member) || party.getPartyMembers().stream().anyMatch(mp -> mp.getMember().equals(member));
     }
+
 
     @Transactional
     public Long joinParty(Party party, Member member) {

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.domain.MessageType;
+import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.chat.service.MessageService;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.party.controller.PartyResponseMessage;
@@ -25,6 +26,7 @@ import java.util.Optional;
 public class PartyMemberService {
     private final PartyMemberRepository memberPartyRepository;
     private final MessageService messageService;
+    private final MessageRepository messageRepository;
 
     public boolean isPartyOwnerOrMember(Party party, Member member) {
         return Optional.ofNullable(party.getOwner()).equals(member) || party.getPartyMembers().stream().anyMatch(mp -> mp.getMember().equals(member));
@@ -46,7 +48,7 @@ public class PartyMemberService {
             throw new PartyJoinException(PartyResponseMessage.PARTY_JOIN_NONOPEN_ERROR);
         }
         // 이 부분 빵판 로직이 들어가야 할 거 같아서 나중에 bbangpan service 로 메소드를 만들어야 할 거 같습니다.
-        PartyMember partyMember = PartyMember.createMemberParty(member, party, messageService.findLastByPartyId(party.getId()));
+        PartyMember partyMember = PartyMember.createMemberParty(member, party, messageRepository.findLastMessage(party.getId()));
         memberPartyRepository.save(partyMember);
 
         return messageService.send(party.getId(), member.getId(), member.getNickname() + " 님이 입장하셨습니다.", MessageType.ENTER);

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -2,6 +2,8 @@ package nbbang.com.nbbang.domain.party.service;
 
 import lombok.RequiredArgsConstructor;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
+import nbbang.com.nbbang.domain.chat.domain.Message;
+import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.dto.Place;
 import nbbang.com.nbbang.domain.member.service.MemberService;
@@ -33,6 +35,7 @@ public class PartyService {
     private final PartyMemberRepository memberPartyRepository;
     private final MemberService memberService;
     private final PartyMemberService partyMemberService;
+    private final MessageRepository messageRepository;
 
     @Transactional
     public Long create(Party party, Long memberId, List<String> hashtagContents) {
@@ -136,5 +139,10 @@ public class PartyService {
         Party party = findById(partyId);
         Integer partyMemberNumber = party.countPartyMemberNumber();
         return partyMemberNumber;
+    }
+
+    public Message findLastMessage(Long partyId) {
+        Message lastMessage = messageRepository.findLastMessage(partyId);
+        return lastMessage;
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -32,15 +32,19 @@ public class PartyService {
     private final HashtagService hashtagService;
     private final PartyMemberRepository memberPartyRepository;
     private final MemberService memberService;
+    private final PartyMemberService partyMemberService;
 
     @Transactional
-    public Long create(Party party, List<String> hashtagContents) {
+    public Long create(Party party, Long memberId, List<String> hashtagContents) {
         Party savedParty = partyRepository.save(party);
         savedParty.changeStatus(PartyStatus.OPEN);
         Long partyId = savedParty.getId();
         // https://sigmasabjil.tistory.com/43
         Optional.ofNullable(hashtagContents).orElseGet(Collections::emptyList).
                 stream().forEach(content-> addHashtag(partyId, content));
+        Member owner = memberService.findById(memberId);
+        partyMemberService.joinParty(savedParty, owner);
+        party.addOwner(owner);
         return partyId;
     }
 

--- a/src/main/java/nbbang/com/nbbang/global/config/StompGlobalWebSocketMessageBrokerConfig.java
+++ b/src/main/java/nbbang/com/nbbang/global/config/StompGlobalWebSocketMessageBrokerConfig.java
@@ -1,0 +1,33 @@
+package nbbang.com.nbbang.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class StompGlobalWebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        WebSocketMessageBrokerConfigurer.super.registerStompEndpoints(registry);
+        registry.addEndpoint("/global").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        WebSocketMessageBrokerConfigurer.super.configureMessageBroker(registry);
+        registry.enableSimpleBroker("/global-topic");
+        registry.setApplicationDestinationPrefixes("/");
+    }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // registration.interceptors(stompHandler);
+    }
+
+}

--- a/src/main/java/nbbang/com/nbbang/global/config/StompWebSocketMessageBrokerConfig.java
+++ b/src/main/java/nbbang/com/nbbang/global/config/StompWebSocketMessageBrokerConfig.java
@@ -30,16 +30,10 @@ public class StompWebSocketMessageBrokerConfig implements WebSocketMessageBroker
         WebSocketMessageBrokerConfigurer.super.configureMessageBroker(registry);
         registry.enableSimpleBroker("/topic"); //토픽, 큐 방식이 있는데 보통 토픽으로함
         registry.setApplicationDestinationPrefixes("/");
-        // client.send('/TTT', {}, ) 컨트롤러에 요청함! /TTT로. 컨트롤러가 받음. 프론트에서 받을때는 토픽을 구독
-/*        컨트롤러 코드는
-          @MessageMapping("/TTT")
-          @SendTo("/topic/message")<- 여기 보내줌
-          public String tttMessage(string message)
-*
-* */
     }
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);
     }
+
 }

--- a/src/main/java/nbbang/com/nbbang/global/handler/StompHandler.java
+++ b/src/main/java/nbbang/com/nbbang/global/handler/StompHandler.java
@@ -3,19 +3,17 @@ package nbbang.com.nbbang.global.handler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nbbang.com.nbbang.domain.chat.dto.ChatReadSocketDto;
 import nbbang.com.nbbang.domain.chat.service.ChatService;
 import nbbang.com.nbbang.domain.chat.service.ChatSessionService;
 import nbbang.com.nbbang.domain.party.service.PartyService;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 // https://daddyprogrammer.org/post/5290/spring-websocket-chatting-server-enter-qut-event-view-user-count/
 // https://stackoverflow.com/questions/44852776/spring-mvc-websockets-with-stomp-authenticate-against-specific-channels
@@ -27,6 +25,7 @@ public class StompHandler implements ChannelInterceptor {
     private final ChatService chatService;
     private final PartyService partyService;
     private final ChatSessionService chatSessionService;
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     // websocket을 통해 들어온 요청이 처리 되기전 실행된다.
     @Override
@@ -42,6 +41,7 @@ public class StompHandler implements ChannelInterceptor {
             chatSessionService.createBySessionIdAndPartyId(sessionId, partyId);
             partyService.updateActiveNumber(partyId, 1);
             log.info("SUBSCRIBED RoomId{}", partyId);
+            readMessage(partyId,1L); // 멤버가 누구인지 검증해야함
 
         } else if (StompCommand.DISCONNECT == accessor.getCommand()) { // Websocket 연결 종료
             log.info("DISCONNECT message = {}",message);
@@ -49,53 +49,16 @@ public class StompHandler implements ChannelInterceptor {
             Long partyId =  chatSessionService.deleteBySessionId(sessionId);
             partyService.updateActiveNumber(partyId, -1);
             log.info("DISCONNECT RoomId{}", partyId);
+            chatService.readMessageForExitChat(partyId,1L); // 멤버가 누구인지 검증해야함
         }
         return message;
     }
-/*
 
-
-    // websocket을 통해 들어온 요청이 처리 되기전 실행된다.
-    @Override
-    public Message<?> preSends(Message<?> message, MessageChannel channel) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-        if (StompCommand.CONNECT == accessor.getCommand()) { // websocket 연결요청
-            String jwtToken = accessor.getFirstNativeHeader("token");
-            log.info("CONNECT {}", jwtToken);
-            // Header의 jwt token 검증
-            jwtTokenProvider.validateToken(jwtToken);
-        } else if (StompCommand.SUBSCRIBE == accessor.getCommand()) { // 채팅룸 구독요청
-v
-        } else if (StompCommand.DISCONNECT == accessor.getCommand()) { // Websocket 연결 종료
-            // 연결이 종료된 클라이언트 sesssionId로 채팅방 id를 얻는다.
-            String sessionId = (String) message.getHeaders().get("simpSessionId");
-            String roomId = chatRoomRepository.getUserEnterRoomId(sessionId);
-            // 채팅방의 인원수를 -1한다.
-            chatRoomRepository.minusUserCount(roomId);
-            // 클라이언트 퇴장 메시지를 채팅방에 발송한다.(redis publish)
-            String name = Optional.ofNullable((Principal) message.getHeaders().get("simpUser")).map(Principal::getName).orElse("UnknownUser");
-            chatService.sendChatMessage(ChatMessage.builder().type(ChatMessage.MessageType.QUIT).roomId(roomId).sender(name).build());
-            // 퇴장한 클라이언트의 roomId 맵핑 정보를 삭제한다.
-            chatRoomRepository.removeUserEnterInfo(sessionId);
-            log.info("DISCONNECTED {}, {}", sessionId, roomId);
-        }
-        return message;
-    }
-}
-*/
-
-
-    private Long updateActiveNumberBySimpDestination(String simpDestination, Integer cnt) {
-        String destination = (simpDestination).substring(7);
-        Long roomId = Long.valueOf(destination).longValue();
-        partyService.updateActiveNumber(roomId, cnt);
-        if(cnt==1){
-            log.info("SUBSCRIBED RoomId{}", roomId);
-        }
-        else if (cnt==-1){
-            log.info("DISCONNECT RoomId{}", roomId);
-        }
-        return roomId;
+    public void readMessage(Long partyId, Long memberId){
+        Long lastReadMessageId = chatService.readMessageForEnterChat(memberId, partyId);
+        ChatReadSocketDto chatReadSocketDto = ChatReadSocketDto.builder().lastReadMessageId(lastReadMessageId).build();
+        simpMessagingTemplate.convertAndSend("/topic/" + partyId, chatReadSocketDto);
+        log.info("[Socket] lastReadMessageId: {}, partyId: {}", lastReadMessageId, partyId);
     }
 
 }

--- a/src/main/java/nbbang/com/nbbang/global/handler/StompHandler.java
+++ b/src/main/java/nbbang/com/nbbang/global/handler/StompHandler.java
@@ -28,7 +28,6 @@ public class StompHandler implements ChannelInterceptor {
     private final ChatSessionService chatSessionService;
     private final PartyMemberService partyMemberService;
 
-
     // websocket을 통해 들어온 요청이 처리 되기전 실행된다.
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/src/main/java/nbbang/com/nbbang/global/interceptor/LoginInterceptor.java
+++ b/src/main/java/nbbang/com/nbbang/global/interceptor/LoginInterceptor.java
@@ -32,7 +32,6 @@ public class LoginInterceptor implements HandlerInterceptor {
         catch (Exception e) {
             this.currentMember.setMemberId(1L);
         }
-        System.out.print("Member :" + currentMember.id() + " ");
         return true;
     }
 }

--- a/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
@@ -59,16 +59,6 @@ public class MockDataCreator implements CommandLineRunner {
     private Long mock3Id;
     private Long mock4Id;
 
-
-    private Long party1Id;
-    private Long party2Id;
-    private Long party3Id;
-    private Long party4Id;
-    private Long party5Id;
-    private Long party6Id;
-    private Long party7Id;
-
-
     private LocalDateTime initTime = LocalDateTime.of(2022, 02, 10, 16, 30);
 
     private LocalDateTime nextTime() {

--- a/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
+++ b/src/main/java/nbbang/com/nbbang/global/support/test/MockDataCreator.java
@@ -11,6 +11,7 @@ import nbbang.com.nbbang.domain.party.domain.Hashtag;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.domain.PartyHashtag;
 import nbbang.com.nbbang.domain.party.domain.PartyStatus;
+import nbbang.com.nbbang.domain.party.dto.single.request.PartyRequestDto;
 import nbbang.com.nbbang.domain.party.repository.HashtagRepository;
 import nbbang.com.nbbang.domain.party.repository.PartyHashtagRepository;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
@@ -193,12 +194,10 @@ public class MockDataCreator implements CommandLineRunner {
                 .content(content)
                 .createTime(nextTime())
                 .goalNumber(goalNumber)
-                .owner(memberRepository.findById(ownerId).get())
                 .place(place)
-                .status(OPEN)
                 .activeNumber(0)
                 .build();
-        partyRepository.save(party);
+        partyService.create(party, ownerId, null);
         addHashtags(party, hashtags);
         if (member1 != null) {
             addMember(party, member1);
@@ -212,7 +211,6 @@ public class MockDataCreator implements CommandLineRunner {
         party.changeStatus(partyStatus);
         return party;
     }
-
 
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,5 +18,4 @@ spring.profiles.include=oauth,aws
 #cloud.aws.region.static=ap-northeast-2
 #cloud.aws.stack.auto=false
 
-
 spring.config.import=optional:file:/home/ubuntu/application-aws.properties,optional:file:/home/ubuntu/application-oauth.properties

--- a/src/test/java/nbbang/com/nbbang/domain/bbangpan/repository/PartyMemberRepositoryTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/bbangpan/repository/PartyMemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package nbbang.com.nbbang.domain.bbangpan.repository;
 
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
+import nbbang.com.nbbang.domain.chat.service.MessageService;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.repository.MemberRepository;
 import nbbang.com.nbbang.domain.party.domain.Party;
@@ -23,6 +24,7 @@ class PartyMemberRepositoryTest {
     PartyMemberRepository memberPartyRepository;
     @Autowired MemberRepository memberRepository;
     @Autowired PartyRepository partyRepository;
+    @Autowired MessageService messageService;
 
     @Test
     public void memberPartySaveAndFindTest() {
@@ -31,7 +33,7 @@ class PartyMemberRepositoryTest {
         memberRepository.save(member);
         Party party = Party.builder().owner(member).goalNumber(10).status(PartyStatus.OPEN).title("party").build();
         partyRepository.save(party);
-        PartyMember savePartyMember = PartyMember.createMemberParty(member, party);
+        PartyMember savePartyMember = PartyMember.createMemberParty(member, party, messageService.findLastByPartyId(party.getId()));
         memberPartyRepository.save(savePartyMember);
         // when
         PartyMember findPartyMember = memberPartyRepository.findByMemberIdAndPartyId(member.getId(), party.getId());

--- a/src/test/java/nbbang/com/nbbang/domain/bbangpan/repository/PartyMemberRepositoryTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/bbangpan/repository/PartyMemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package nbbang.com.nbbang.domain.bbangpan.repository;
 
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
+import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.chat.service.MessageService;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.repository.MemberRepository;
@@ -25,6 +26,8 @@ class PartyMemberRepositoryTest {
     @Autowired MemberRepository memberRepository;
     @Autowired PartyRepository partyRepository;
     @Autowired MessageService messageService;
+    @Autowired
+    MessageRepository messageRepository;
 
     @Test
     public void memberPartySaveAndFindTest() {
@@ -33,7 +36,7 @@ class PartyMemberRepositoryTest {
         memberRepository.save(member);
         Party party = Party.builder().owner(member).goalNumber(10).status(PartyStatus.OPEN).title("party").build();
         partyRepository.save(party);
-        PartyMember savePartyMember = PartyMember.createMemberParty(member, party, messageService.findLastByPartyId(party.getId()));
+        PartyMember savePartyMember = PartyMember.createMemberParty(member, party, messageRepository.findLastMessage(party.getId()));
         memberPartyRepository.save(savePartyMember);
         // when
         PartyMember findPartyMember = memberPartyRepository.findByMemberIdAndPartyId(member.getId(), party.getId());

--- a/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
@@ -1,21 +1,21 @@
 package nbbang.com.nbbang.domain.chat.service;
 
+import lombok.extern.slf4j.Slf4j;
+import nbbang.com.nbbang.domain.chat.controller.ChatRoomController;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.service.PartyMemberService;
 import nbbang.com.nbbang.domain.party.service.PartyService;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@Slf4j
 class ChatReadTest {
 
     @Autowired ChatService chatService;
@@ -23,20 +23,47 @@ class ChatReadTest {
     @Autowired MemberService memberService;
     @Autowired PartyMemberService partyMemberService;
     @Autowired MessageService messageService;
+    @Autowired ChatRoomController chatRoomController;
 
     @Test
     void readMessageTest() {
-
         Long partyId = 1L;
         join(partyId, 4L); // 파티 1번에는 1~4까지 4명이 존재함
-        Long messageId = messageService.send(partyId, 3L, "hello");
+        partyService.updateActiveNumber(partyId, 1); // 1번 파티 입장
+        chatRoomController.readMessage(partyId, 1L); // 1번 파티 입장
+        Long messageId1 = messageService.send(partyId, 1L, "hello");
+        Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(1);
 
+        partyService.updateActiveNumber(partyId, 1); // 2번 파티 입장
+        chatService.readMessage(partyId, 2L); // 2번 파티 입장
+        Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
+
+        Long messageId2 = messageService.send(partyId, 2L, "hello here 2");
+        Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
+        Assertions.assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(2);
+
+        partyService.updateActiveNumber(partyId, -1); // 1번 파티 나감
+        chatService.exitChat(partyId, 1L); // 1번 파티 나감
+        Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
+
+        partyService.updateActiveNumber(partyId, 1); // 3번 파티 입장
+        chatService.readMessage(partyId, 3L); // 3번 파티 입장
+        Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(3);
+        Assertions.assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(3);
+        Long messageId3 = messageService.send(partyId, 3L, "hello here 3");
+        Assertions.assertThat(messageService.findById(messageId3).getReadNumber()).isEqualTo(2);
+
+        partyService.updateActiveNumber(partyId, 1); // 1번 파티 재입장
+        chatService.readMessage(partyId, 1L); // 1번 파티 재입장
+        Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(3);
+        Assertions.assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(3);
+        Assertions.assertThat(messageService.findById(messageId3).getReadNumber()).isEqualTo(3);
 
     }
 
     void join(Long partyId, Long memberId) {
         Party party = partyService.findById(partyId);
         Member member = memberService.findById(memberId);
-        Long messageId = partyMemberService.joinParty(party, member);
+        partyMemberService.joinParty(party, member);
     }
 }

--- a/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
@@ -22,14 +22,15 @@ class ChatReadTest {
     @Autowired PartyService partyService;
     @Autowired MemberService memberService;
     @Autowired PartyMemberService partyMemberService;
+    @Autowired MessageService messageService;
 
     @Test
     void readMessageTest() {
-        join(1L, 1L);
-        join(1L, 4L);
-        join(1L, 5L);
-        join(1L, 6L);
-        // SIX MEMBERS IN PARTY 1
+
+        Long partyId = 1L;
+        join(partyId, 4L); // 파티 1번에는 1~4까지 4명이 존재함
+        Long messageId = messageService.send(partyId, 3L, "hello");
+
 
     }
 

--- a/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
@@ -3,6 +3,7 @@ package nbbang.com.nbbang.domain.chat.service;
 import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.chat.controller.ChatRoomController;
 import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.repository.MemberRepository;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.service.PartyMemberService;
@@ -11,50 +12,68 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import static nbbang.com.nbbang.domain.member.dto.Place.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 @Slf4j
 class ChatReadTest {
 
     @Autowired ChatService chatService;
     @Autowired PartyService partyService;
     @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
     @Autowired PartyMemberService partyMemberService;
     @Autowired MessageService messageService;
     @Autowired ChatRoomController chatRoomController;
 
     @Test
     void readMessageTest() {
-        Long partyId = 1L;
-        join(partyId, 4L); // 파티 1번에는 1~4까지 4명이 존재함
+        Member member = Member.builder().nickname("test member").build();
+        Member saveMember1 = memberRepository.save(member);
+        Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(4).build();
+        Long partyId = partyService.create(party,saveMember1.getId(), null);
+        Member member2 = Member.builder().nickname("test member").build();
+        Member saveMember2 = memberRepository.save(member2);
+        Member member3 = Member.builder().nickname("test member").build();
+        Member saveMember3 = memberRepository.save(member3);
+
+
+        join(partyId, saveMember2.getId());
+        join(partyId, saveMember3.getId());
+        // 파티에는 1~3까지 3명이 존재함
+
         partyService.updateActiveNumber(partyId, 1); // 1번 파티 입장
-        chatRoomController.readMessage(partyId, 1L); // 1번 파티 입장
-        Long messageId1 = messageService.send(partyId, 1L, "hello");
+        chatRoomController.readMessage(partyId, saveMember1.getId()); // 1번 파티 입장
+        Long messageId1 = messageService.send(partyId, saveMember1.getId(), "hello");
         Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(1);
 
         partyService.updateActiveNumber(partyId, 1); // 2번 파티 입장
-        chatService.readMessage(partyId, 2L); // 2번 파티 입장
+        chatService.readMessage(partyId, saveMember2.getId()); // 2번 파티 입장
         Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
 
-        Long messageId2 = messageService.send(partyId, 2L, "hello here 2");
+        Long messageId2 = messageService.send(partyId, saveMember2.getId(), "hello here 2");
         Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
         Assertions.assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(2);
 
         partyService.updateActiveNumber(partyId, -1); // 1번 파티 나감
-        chatService.exitChat(partyId, 1L); // 1번 파티 나감
+        chatService.exitChatRoom(partyId, saveMember1.getId()); // 1번 파티 나감
         Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
 
         partyService.updateActiveNumber(partyId, 1); // 3번 파티 입장
-        chatService.readMessage(partyId, 3L); // 3번 파티 입장
+        chatService.readMessage(partyId, saveMember3.getId()); // 3번 파티 입장
         Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(3);
         Assertions.assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(3);
-        Long messageId3 = messageService.send(partyId, 3L, "hello here 3");
+
+        Long messageId3 = messageService.send(partyId, saveMember3.getId(), "hello here 3");
         Assertions.assertThat(messageService.findById(messageId3).getReadNumber()).isEqualTo(2);
 
         partyService.updateActiveNumber(partyId, 1); // 1번 파티 재입장
-        chatService.readMessage(partyId, 1L); // 1번 파티 재입장
+        chatService.readMessage(partyId, saveMember1.getId()); // 1번 파티 재입장
         Assertions.assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(3);
         Assertions.assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(3);
         Assertions.assertThat(messageService.findById(messageId3).getReadNumber()).isEqualTo(3);
@@ -66,4 +85,6 @@ class ChatReadTest {
         Member member = memberService.findById(memberId);
         partyMemberService.joinParty(party, member);
     }
+
+
 }

--- a/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
@@ -1,0 +1,41 @@
+package nbbang.com.nbbang.domain.chat.service;
+
+import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.service.MemberService;
+import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.service.PartyMemberService;
+import nbbang.com.nbbang.domain.party.service.PartyService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ChatReadTest {
+
+    @Autowired ChatService chatService;
+    @Autowired PartyService partyService;
+    @Autowired MemberService memberService;
+    @Autowired PartyMemberService partyMemberService;
+
+    @Test
+    void readMessageTest() {
+        join(1L, 1L);
+        join(1L, 4L);
+        join(1L, 5L);
+        join(1L, 6L);
+        // SIX MEMBERS IN PARTY 1
+
+    }
+
+    void join(Long partyId, Long memberId) {
+        Party party = partyService.findById(partyId);
+        Member member = memberService.findById(memberId);
+        Long messageId = partyMemberService.joinParty(party, member);
+    }
+}

--- a/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatServiceTest.java
@@ -1,5 +1,6 @@
 package nbbang.com.nbbang.domain.chat.service;
 
+import nbbang.com.nbbang.domain.chat.controller.ChatRoomController;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
@@ -27,6 +28,7 @@ class ChatServiceTest {
     @Autowired ChatService chatService;
     @Autowired PartyRepository partyRepository;
     @Autowired MemberRepository memberRepository;
+
 
     @Test
     public void sendAndFindMessageTest() {

--- a/src/test/java/nbbang/com/nbbang/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/party/service/PartyServiceTest.java
@@ -50,12 +50,13 @@ class PartyServiceTest {
     public void partyJoin_DuplicateJoinTest1() {
         // given
         Member memberA = Member.builder().nickname("memberA").build();
-        memberRepository.save(memberA);
+        Member saveMember = memberRepository.save(memberA);
         Party partyA = Party.builder().owner(memberA).goalNumber(10).status(PartyStatus.OPEN).build();
-        partyRepository.save(partyA);
+        partyService.create(partyA, saveMember.getId(), null);
         // when // then
         assertThrows(PartyJoinException.class, () -> {
-            partyMemberService.joinParty(partyA, memberA);});
+            partyMemberService.joinParty(partyA, memberA);
+        });
     }
 
     @Test
@@ -99,7 +100,8 @@ class PartyServiceTest {
         Member memberB = Member.builder().nickname("memberB").build();
         memberRepository.save(memberB);
         Party partyA = Party.builder().owner(memberA).goalNumber(3).status(PartyStatus.OPEN).build();
-        partyRepository.save(partyA);
+        partyService.create(partyA, memberA.getId(), null);
+        // partyRepository.save(partyA);
         // when
         partyMemberService.joinParty(partyA, memberB);
         // then

--- a/src/test/java/nbbang/com/nbbang/domain/party/service/SinglePartyServiceTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/party/service/SinglePartyServiceTest.java
@@ -1,5 +1,7 @@
 package nbbang.com.nbbang.domain.party.service;
 
+import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.domain.PartyStatus;
 import nbbang.com.nbbang.domain.party.dto.single.request.PartyRequestDto;
@@ -29,6 +31,8 @@ class SinglePartyServiceTest {
     @Autowired PartyService partyService;
     @Autowired PartyRepository partyRepository;
     @Autowired EntityManager em;
+    @Autowired
+    MemberService memberService;
 
     @Test
     public void createParty(){
@@ -36,7 +40,7 @@ class SinglePartyServiceTest {
         List<String> hashtagContents = Arrays.asList("old1", "old2");
         Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(3).build();
         // when
-        Long createdPartyId = partyService.create(party, hashtagContents);
+        Long createdPartyId = partyService.create(party, 3L, hashtagContents);
         // then
         Party findParty = partyRepository.findById(createdPartyId).orElse(null);
         assertThat(findParty).isEqualTo(party);
@@ -48,7 +52,7 @@ class SinglePartyServiceTest {
         // given
         List<String> hashtagContents = Arrays.asList("old1", "old2");
         Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(3).build();
-        Long createdPartyId = partyService.create(party, hashtagContents);
+        Long createdPartyId = partyService.create(party, 4L, hashtagContents);
         // when
         Party findParty = partyService.findById(createdPartyId);
         // then
@@ -75,7 +79,7 @@ class SinglePartyServiceTest {
     @Test
     void findNearAndSimilar() {
         Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(3).build();
-        Long createdPartyId = partyService.create(party, null);
+        Long createdPartyId = partyService.create(party,4L, null);
 
         // when
         List<Party> findParties = partyService.findNearAndSimilar(createdPartyId);

--- a/src/test/java/nbbang/com/nbbang/domain/party/service/SinglePartyServiceTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/party/service/SinglePartyServiceTest.java
@@ -1,6 +1,7 @@
 package nbbang.com.nbbang.domain.party.service;
 
 import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.repository.MemberRepository;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.domain.PartyStatus;
@@ -25,22 +26,23 @@ import static org.assertj.core.api.Assertions.*;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-// @Rollback(false)
 class SinglePartyServiceTest {
 
     @Autowired PartyService partyService;
     @Autowired PartyRepository partyRepository;
     @Autowired EntityManager em;
     @Autowired
-    MemberService memberService;
+    MemberRepository memberRepository;
 
     @Test
     public void createParty(){
         // given
+        Member member = Member.builder().nickname("test member").build();
+        Member saveMember = memberRepository.save(member);
         List<String> hashtagContents = Arrays.asList("old1", "old2");
         Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(3).build();
         // when
-        Long createdPartyId = partyService.create(party, 3L, hashtagContents);
+        Long createdPartyId = partyService.create(party, saveMember.getId(), hashtagContents);
         // then
         Party findParty = partyRepository.findById(createdPartyId).orElse(null);
         assertThat(findParty).isEqualTo(party);
@@ -50,9 +52,11 @@ class SinglePartyServiceTest {
     @Test
     void findParty() {
         // given
+        Member member = Member.builder().nickname("test member").build();
+        Member saveMember = memberRepository.save(member);
         List<String> hashtagContents = Arrays.asList("old1", "old2");
         Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(3).build();
-        Long createdPartyId = partyService.create(party, 4L, hashtagContents);
+        Long createdPartyId = partyService.create(party, saveMember.getId(), hashtagContents);
         // when
         Party findParty = partyService.findById(createdPartyId);
         // then
@@ -78,8 +82,10 @@ class SinglePartyServiceTest {
 
     @Test
     void findNearAndSimilar() {
+        Member member = Member.builder().nickname("test member").build();
+        Member saveMember = memberRepository.save(member);
         Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(3).build();
-        Long createdPartyId = partyService.create(party,4L, null);
+        Long createdPartyId = partyService.create(party,saveMember.getId(), null);
 
         // when
         List<Party> findParties = partyService.findNearAndSimilar(createdPartyId);


### PR DESCRIPTION
- 채팅 읽음 처리 로직을 구현했습니다. 
- 유저가 들어오면 모든 유저에게 어디부터 NotRead수를 줄여야 하는지 소켓을 보냅니다.
- 유저가 나갈 때 마지막으로 읽은 메시지를 업데이트 합니다.
- 테스트 결과 잘 동작합니다.
- 또한, 채팅 읽음은 아니지만 테스트 하면서 발견한 것으로, 방장은 partyMember 데이터가 생기지 않아서 수정하였습니다.
