### PR TITLE
채팅 메시지 목록을 찾을 때 파티를 먼저 조회하고 메시지를 읽도록 코드 순서 변경

### DIFF
--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
@@ -62,8 +62,9 @@ public class ChatRoomController {
     @ApiResponse(responseCode = "403", description = "Not Party Member", content = @Content(mediaType = "application/json"))
     @GetMapping("/{party-id}/messages")
     public DefaultResponse selectChatMessages(@PathVariable("party-id") Long partyId, @ParameterObject PageableDto pageableDto, @RequestParam(required = false) Long cursorId) {
-        readMessage(partyId,currentMember.id()); // 채팅방에 들어오면 읽음을 처리합니다. 위치를 수정해도 될 것 같습니다.
+
         Party party = partyService.findById(partyId);
+        readMessage(partyId,currentMember.id()); // 채팅방에 들어오면 읽음을 처리합니다. 위치를 수정해도 될 것 같습니다.
         if (cursorId == null) {
             cursorId = chatService.findLastMessage(party).getId();
         }


### PR DESCRIPTION
파티가 없으면 에러를 반환하는 로직이 먼저 불리지 않아 순서를 변경합니다. 