### PR TITLE
참여한 파티의 읽지 않은 채팅 개수 조회

### DIFF
--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/controller/BbangpanController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/controller/BbangpanController.java
@@ -103,7 +103,7 @@ public class BbangpanController {
         if (bindingResult.hasErrors()) {
             throw new CustomIllegalArgumentException(PartyResponseMessage.ILLEGAL_PARTY_STATUS, bindingResult);
         }
-        changePartyMemberField(partyId, currentMember.id(), PartyMember.getField("sendStatus"), sendStatusChangeRequestDto.createStatus());
+        changePartyMemberField(partyId, currentMember.id(), PartyMember.getField("isSent"), sendStatusChangeRequestDto.getIsSent());
         return DefaultResponse.res(StatusCode.OK, BbangpanResponseMessage.SENDSTATUS_CHANGE_SUCCESS);
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
@@ -27,7 +27,7 @@ public class PartyMember {
 
     @OneToOne
     @JoinColumn(name = "message_id")
-    private Message lastReadMessage;
+    private Message lastReadMessage = Message.builder().build();
 
     @ManyToOne
     @JoinColumn(name = "member_id")

--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/domain/PartyMember.java
@@ -11,8 +11,6 @@ import javax.persistence.*;
 
 import java.lang.reflect.Field;
 
-import static javax.persistence.EnumType.STRING;
-
 @Entity @Getter @Builder
 @AllArgsConstructor
 public class PartyMember {
@@ -22,8 +20,8 @@ public class PartyMember {
     @Builder.Default
     private Integer price=0;
 
-    @Enumerated(STRING)
-    private SendStatus sendStatus;
+    @Builder.Default
+    private Boolean isSent = false;
 
     @OneToOne
     @JoinColumn(name = "message_id")
@@ -57,8 +55,8 @@ public class PartyMember {
         this.price = price;
     }
 
-    public void changeSendStatus(SendStatus sendStatus) {
-        this.sendStatus = sendStatus;
+    public void changeIsSent(Boolean isSent) {
+        this.isSent = isSent;
     }
 
     public static Field getField(String field) throws NoSuchFieldException {

--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/dto/PartyMemberResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/dto/PartyMemberResponseDto.java
@@ -21,7 +21,7 @@ public class PartyMemberResponseDto {
 
     private Long id;
     private Integer price;
-    private SendStatus sendStatus;
+    private Boolean isSent;
     private Boolean isOwner;
     private String nickname;
     private String avatar;
@@ -30,7 +30,7 @@ public class PartyMemberResponseDto {
         PartyMemberResponseDto partyMemberResponseDto = PartyMemberResponseDto.builder()
                 .id(partyMember.getMember().getId())
                 .price(partyMember.getPrice())
-                .sendStatus(partyMember.getSendStatus())
+                .isSent(partyMember.getIsSent())
                 .isOwner(partyMember.getMember().getId() == partyMember.getParty().getOwner().getId())
                 .nickname(partyMember.getMember().getNickname())
                 .avatar(partyMember.getMember().getAvatar())

--- a/src/main/java/nbbang/com/nbbang/domain/bbangpan/dto/request/SendStatusChangeRequestDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/bbangpan/dto/request/SendStatusChangeRequestDto.java
@@ -8,16 +8,14 @@ import nbbang.com.nbbang.domain.bbangpan.domain.SendStatus;
 import nbbang.com.nbbang.domain.party.domain.PartyStatus;
 import nbbang.com.nbbang.global.support.validation.ValueOfEnum;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.Locale;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class SendStatusChangeRequestDto {
-    @ValueOfEnum(enumClass = SendStatus.class) @Schema(description = "올바른 status 값: NONE, SEND, CHECK")
-    private String sendStatus;
-
-    public SendStatus createStatus() {
-        return SendStatus.valueOf(sendStatus.toUpperCase(Locale.ROOT));
-    }
+    @NotNull(message = "송금 상태는 필수 값입니다.")
+    private Boolean isSent;
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepository.java
@@ -18,4 +18,6 @@ public interface MessageRepository extends JpaRepository<Message, Long>, Message
 
     Long countByPartyId(Long partyId);
 
+    Integer countByPartyIdAndIdGreaterThan(Long partyId, Long id);
+
 }

--- a/src/main/java/nbbang/com/nbbang/domain/member/controller/MemberResponseMessage.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/controller/MemberResponseMessage.java
@@ -6,6 +6,8 @@ public class MemberResponseMessage {
     public static final String LOGIN_FAIL = "로그인 실패";
     public static final String READ_MEMBER = "회원 정보 조회 성공";
 
+    public static final String READ_MY_PARTY = "나의 파티 목록 조회 성공";
+
     public static final String NOT_FOUND_MEMBER = "회원을 찾을 수 없습니다.";
     public static final String CREATED_MEMBER = "회원 가입 성공";
     public static final String UPDATE_MEMBER = "회원 정보 수정 성공";

--- a/src/main/java/nbbang/com/nbbang/domain/member/controller/MyPartiesController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/controller/MyPartiesController.java
@@ -15,6 +15,7 @@ import nbbang.com.nbbang.domain.party.dto.my.MyClosedPartyListRequestDto;
 import nbbang.com.nbbang.domain.party.dto.my.MyOnPartyListRequestDto;
 import nbbang.com.nbbang.domain.party.dto.my.MyPartyListResponseDto;
 import nbbang.com.nbbang.domain.party.service.ManyPartyService;
+import nbbang.com.nbbang.domain.party.service.PartyMemberService;
 import nbbang.com.nbbang.global.error.exception.CustomIllegalArgumentException;
 import nbbang.com.nbbang.global.interceptor.CurrentMember;
 import nbbang.com.nbbang.global.response.DefaultResponse;
@@ -23,6 +24,8 @@ import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "MyParties", description = "나의 파티 api 로그인을 하지 않은 경우 ID=1 인 회원(루피)으로 표시됩니다.")
 @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(mediaType = "application/json"))
@@ -33,6 +36,7 @@ import org.springframework.web.bind.annotation.*;
 public class MyPartiesController {
 
     private final ManyPartyService manyPartyService;
+    private final PartyMemberService partyMemberService;
     private final CurrentMember currentMember;
 
     @Operation(summary = "나의 파티", description = "자신이 속한 파티 목록을 조회합니다.")
@@ -54,7 +58,8 @@ public class MyPartiesController {
             throw new CustomIllegalArgumentException(ManyPartyResponseMessage.ILLEGAL_PARTY_LIST_REQUEST, bindingResult);
         }
         Page<Party> res = manyPartyService.findAllParties(requestDto.createPageRequest(), true, requestDto.createPartyListRequestFilterDto(), requestDto.getCursorId(), currentMember.id(), null);
-        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MEMBER, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id()));
+        List<Integer> notReadNumbers = partyMemberService.getNotReadNumber(res.getContent(), currentMember.id());
+        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MEMBER, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id(), notReadNumbers));
     }
 
     @Operation(summary = "나의 종료된 파티", description = "자신이 속한 종료된 파티 목록을 조회합니다.")

--- a/src/main/java/nbbang/com/nbbang/domain/member/controller/MyPartiesController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/member/controller/MyPartiesController.java
@@ -40,18 +40,18 @@ public class MyPartiesController {
     private final CurrentMember currentMember;
 
     @Operation(summary = "나의 파티", description = "자신이 속한 파티 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MyPartyListResponseDto.class)))
     @GetMapping("/develop")
     public DefaultResponse parties(@ParameterObject PartyListRequestDto requestDto, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new CustomIllegalArgumentException(ManyPartyResponseMessage.ILLEGAL_PARTY_LIST_REQUEST, bindingResult);
         }
         Page<Party> res = manyPartyService.findAllParties(requestDto.createPageRequest(), true, requestDto.createPartyListRequestFilterDto(), requestDto.getCursorId(), currentMember.id(), null);
-        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MEMBER, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id()));
+        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MY_PARTY, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id()));
     }
 
     @Operation(summary = "나의 참여중인 파티", description = "자신이 속한 참여 중(OPEN, FULL)인 파티 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MyPartyListResponseDto.class)))
     @GetMapping("/on")
     public DefaultResponse partiesOn(@ParameterObject MyOnPartyListRequestDto requestDto, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
@@ -59,18 +59,18 @@ public class MyPartiesController {
         }
         Page<Party> res = manyPartyService.findAllParties(requestDto.createPageRequest(), true, requestDto.createPartyListRequestFilterDto(), requestDto.getCursorId(), currentMember.id(), null);
         List<Integer> notReadNumbers = partyMemberService.getNotReadNumber(res.getContent(), currentMember.id());
-        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MEMBER, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id(), notReadNumbers));
+        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MY_PARTY, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id(), notReadNumbers));
     }
 
     @Operation(summary = "나의 종료된 파티", description = "자신이 속한 종료된 파티 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PartyListResponseDto.class)))
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MyPartyListResponseDto.class)))
     @GetMapping("/closed")
     public DefaultResponse partiesClosed(@ParameterObject MyClosedPartyListRequestDto requestDto, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new CustomIllegalArgumentException(ManyPartyResponseMessage.ILLEGAL_PARTY_LIST_REQUEST, bindingResult);
         }
         Page<Party> res = manyPartyService.findAllParties(requestDto.createPageRequest(), true, requestDto.createPartyListRequestFilterDto(), requestDto.getCursorId(), currentMember.id(), null);
-        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MEMBER, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id()));
+        return DefaultResponse.res(StatusCode.OK, MemberResponseMessage.READ_MY_PARTY, MyPartyListResponseDto.createFromEntity(res.getContent(), currentMember.id()));
     }
 
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/domain/Party.java
@@ -44,7 +44,8 @@ public class Party {
     @Column(updatable = false)
     private LocalDateTime createTime;
 
-    private Integer goalNumber;
+    @Builder.Default
+    private Integer goalNumber=1;
 
     //@ValueOfEnum(enumClass = PartyStatus.class)
     @Enumerated(STRING)

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/my/MyPartyListResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/my/MyPartyListResponseDto.java
@@ -17,6 +17,11 @@ import java.util.stream.Collectors;
 public class MyPartyListResponseDto {
     List<MyPartyResponseDto> parties;
 
+    public static MyPartyListResponseDto createFromEntity(List<Party> partyList, Long memberId, List<Integer> notReadNumbers) {
+        return MyPartyListResponseDto.builder()
+                .parties(partyList.stream().map(p -> MyPartyResponseDto.createByEntity(p, memberId, notReadNumbers.get(partyList.indexOf(p)))).collect(Collectors.toList()))
+                .build();
+    }
     public static MyPartyListResponseDto createFromEntity(List<Party> partyList, Long memberId) {
         return MyPartyListResponseDto.builder()
                 .parties(partyList.stream().map(p -> MyPartyResponseDto.createByEntity(p, memberId)).collect(Collectors.toList()))

--- a/src/main/java/nbbang/com/nbbang/domain/party/dto/my/MyPartyResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/dto/my/MyPartyResponseDto.java
@@ -28,6 +28,7 @@ public class MyPartyResponseDto{
     private Boolean isOwner;
     private List<String> hashtags;
     private List<MemberSimpleResponseDto> members;
+    private Integer notReadNumber;
 
     public static MyPartyResponseDto createByEntity(Party party, Long memberId) {
         return MyPartyResponseDto.builder()
@@ -42,6 +43,23 @@ public class MyPartyResponseDto{
                 .isOwner(memberId == party.getOwner().getId())
                 .members(party.getPartyMembers().stream().map(mp -> MemberSimpleResponseDto.createByEntity(mp.getMember())).collect(Collectors.toList()))
                 .place(party.getPlace().toString())
+                .build();
+    }
+
+    public static MyPartyResponseDto createByEntity(Party party, Long memberId, Integer notReadNumber) {
+        return MyPartyResponseDto.builder()
+                .id(party.getId())
+                .title(party.getTitle())
+                .createTime(party.getCreateTime())
+                .goalNumber(party.getGoalNumber())
+                .joinNumber(party.getPartyMembers().size() + 1)
+                .owner(MemberSimpleResponseDto.createByEntity(party.getOwner()))
+                .status(party.getStatus()!=null?party.getStatus().toString():null)
+                .hashtags(party.getHashtagContents())
+                .isOwner(memberId == party.getOwner().getId())
+                .members(party.getPartyMembers().stream().map(mp -> MemberSimpleResponseDto.createByEntity(mp.getMember())).collect(Collectors.toList()))
+                .place(party.getPlace().toString())
+                .notReadNumber(notReadNumber)
                 .build();
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/ManyPartyRepositorySupportImpl.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
+import static nbbang.com.nbbang.domain.bbangpan.domain.QPartyMember.partyMember;
+
 @RequiredArgsConstructor
 public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySupport {
 
@@ -67,7 +69,9 @@ public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySuppor
 
         // 자신이 속한 파티 필터링을 제공합니다
         if (isMyParties) {
-            q.where(isMemberOfParty(memberId));
+            q.where(isMemberOfParty(memberId))
+                    .join(party.partyMembers, partyMember).fetchJoin()
+                    .where(partyMember.member.id.eq(memberId));
         }
 
         // 표시하지 않을 파티를 제공합니다
@@ -152,7 +156,7 @@ public class ManyPartyRepositorySupportImpl implements ManyPartyRepositorySuppor
 
     private BooleanBuilder isMemberOfParty(Long memberId) {
         QParty party = QParty.party;
-        QPartyMember mp = QPartyMember.partyMember;
+        QPartyMember mp = partyMember;
         BooleanBuilder builder = new BooleanBuilder();
         builder.or(party.owner.id.eq(memberId));
         builder.or(party.partyMembers.any().member.id.eq(memberId));

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/PartyRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/PartyRepository.java
@@ -14,5 +14,4 @@ import java.util.List;
 public interface PartyRepository extends JpaRepository<Party, Long>, PartyRepositorySupport{
     Page<Party> findAll(Pageable pageable);
     Party findByTitle(String title);
-
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/repository/SessionPartyGlobalRepository.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/repository/SessionPartyGlobalRepository.java
@@ -38,4 +38,12 @@ public class SessionPartyGlobalRepository {
         return Integer.valueOf((int) count);
     }
 
+    public Boolean isActive(Long partyId, Long memberId) {
+        Pair<Long, Long> pair = new Pair<>(partyId, memberId);
+        if(sessionPartyMap.containsKey(pair) &&  (sessionPartyMap.get(pair) > 0)){
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/ManyPartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/ManyPartyService.java
@@ -1,6 +1,7 @@
 package nbbang.com.nbbang.domain.party.service;
 
 import lombok.RequiredArgsConstructor;
+import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.dto.many.PartyFindRequestFilterDto;
 import nbbang.com.nbbang.domain.party.dto.many.PartyListRequestFilterDto;
@@ -17,9 +18,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ManyPartyService {
     private final ManyPartyRepository manyPartyRepository;
+    private final MessageRepository messageRepository;
 
     public Page<Party> findAllParties(Pageable pageable, Boolean isMyParties, PartyListRequestFilterDto filter, Long cursorId, Long memberId, List<String> hashtags, Long ... partyId) {
         return manyPartyRepository.findAllParties(pageable, isMyParties, filter, cursorId, memberId, hashtags, partyId);
     }
-    
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
@@ -20,7 +20,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly=true)
@@ -90,6 +92,19 @@ public class PartyMemberService {
     @Transactional
     public void updateLastReadMessage(PartyMember partyMember, Message currentLastMessage) {
         partyMember.changeLastReadMessage(currentLastMessage);
+    }
+
+    public Message findLastReadMessage(Long partyId, Long memberId) {
+        PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
+        return Optional.ofNullable(partyMember.getLastReadMessage()).orElse(Message.builder().id(0L).build());
+    }
+
+
+    public List getNotReadNumber(List<Party> parties, Long memberId) {
+        List<Integer> notReadNumber = parties.stream().map(party -> messageRepository
+                .countByPartyIdAndIdGreaterThan(party.getId(), findLastReadMessage(party.getId(), memberId).getId())).collect(Collectors.toList());
+
+        return notReadNumber;
     }
 
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyMemberService.java
@@ -3,7 +3,6 @@ package nbbang.com.nbbang.domain.party.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
-import nbbang.com.nbbang.domain.bbangpan.domain.SendStatus;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.chat.domain.MessageType;
@@ -24,7 +23,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly=true)
@@ -85,10 +83,10 @@ public class PartyMemberService {
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
         if (field.equals(PartyMember.getField("price"))){
             partyMember.changePrice((Integer) value);
-        }else if(field.equals(PartyMember.getField("sendStatus"))){
-            partyMember.changeSendStatus((SendStatus) value);
+        }else if(field.equals(PartyMember.getField("isSent"))){
+            partyMember.changeIsSent((Boolean) value);
         }else{
-            log.info("no such status");
+            log.info("no such field");
         }
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -1,6 +1,7 @@
 package nbbang.com.nbbang.domain.party.service;
 
 import lombok.RequiredArgsConstructor;
+import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
@@ -32,7 +33,7 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final PartyHashtagRepository partyHashtagRepository;
     private final HashtagService hashtagService;
-    private final PartyMemberRepository memberPartyRepository;
+    private final PartyMemberRepository partyMemberRepository;
     private final MemberService memberService;
     private final PartyMemberService partyMemberService;
     private final MessageRepository messageRepository;
@@ -153,4 +154,11 @@ public class PartyService {
         }
     }
 
+
+    public Integer getNotReadMessageNumber(Long partyId, Long memberId){
+        PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
+        Long lastReadMessageId = (Optional.ofNullable(partyMember.getLastReadMessage()).orElse(Message.builder().id(0L).build())).getId();
+        long count = messageRepository.countByPartyIdAndIdGreaterThan(partyId, lastReadMessageId);
+        return (int) count;
+    }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -139,7 +139,7 @@ public class PartyService {
 
     public Message findLastMessage(Long partyId) {
         Message lastMessage = messageRepository.findLastMessage(partyId);
-        return lastMessage;
+        return Optional.ofNullable(lastMessage).orElse(Message.builder().id(0L).build());
     }
 
 
@@ -154,11 +154,4 @@ public class PartyService {
         }
     }
 
-
-    public Integer getNotReadMessageNumber(Long partyId, Long memberId){
-        PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
-        Long lastReadMessageId = (Optional.ofNullable(partyMember.getLastReadMessage()).orElse(Message.builder().id(0L).build())).getId();
-        long count = messageRepository.countByPartyIdAndIdGreaterThan(partyId, lastReadMessageId);
-        return (int) count;
-    }
 }

--- a/src/main/java/nbbang/com/nbbang/global/config/WebMvcConfig.java
+++ b/src/main/java/nbbang/com/nbbang/global/config/WebMvcConfig.java
@@ -28,15 +28,16 @@ public class WebMvcConfig implements WebMvcConfigurer {
        List<String> partyMemberInterceptorUrlPatterns = Arrays.asList("/chats/*", "/bread-board/*");
        List<String> ownerInterceptorUrlPatterns =
                 Arrays.asList("/parties/*", "/bread-board/*/delivery-fee", "/bread-board/*/account");
-
+        List<String> ownerInterceptorExcludeUrlPatterns =
+                Arrays.asList("/parties/*/wishlist", "/parties/*/join", "/parties/*/exit");
 
         registry.addInterceptor(partyMemberInterceptor)
                 .addPathPatterns(partyMemberInterceptorUrlPatterns)
                 .excludePathPatterns(ownerInterceptorUrlPatterns);
 
-
         registry.addInterceptor(ownerInterceptor)
-               .addPathPatterns(ownerInterceptorUrlPatterns);
+               .addPathPatterns(ownerInterceptorUrlPatterns)
+                .excludePathPatterns(ownerInterceptorExcludeUrlPatterns);
 
     }
 }

--- a/src/main/java/nbbang/com/nbbang/global/error/GlobalControllerAdvice.java
+++ b/src/main/java/nbbang/com/nbbang/global/error/GlobalControllerAdvice.java
@@ -7,6 +7,7 @@ import nbbang.com.nbbang.global.error.exception.*;
 import nbbang.com.nbbang.global.response.StatusCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.web.firewall.RequestRejectedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -65,6 +66,13 @@ public class GlobalControllerAdvice {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ErrorResponse notFoundExceptionHandle(NoHandlerFoundException e) {
         log.error("[ExceptionHandle] NoHandlerFoundException: ", e);
+        return ErrorResponse.res(StatusCode.NOT_FOUND, GlobalErrorResponseMessage.REQUEST_URL_ERROR);
+    }
+
+
+    @ExceptionHandler(RequestRejectedException.class)
+    public ErrorResponse requestRejectionExceptionHandle(RequestRejectedException e) {
+        log.error("[ExceptionHandle] requestRejectionExceptionHandle: ", e);
         return ErrorResponse.res(StatusCode.NOT_FOUND, GlobalErrorResponseMessage.REQUEST_URL_ERROR);
     }
 

--- a/src/test/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositoryTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositoryTest.java
@@ -2,10 +2,13 @@ package nbbang.com.nbbang.domain.chat.repository;
 
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.chat.service.ChatService;
+import nbbang.com.nbbang.domain.chat.service.MessageService;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.repository.MemberRepository;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
+import nbbang.com.nbbang.domain.party.service.PartyService;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,6 +26,10 @@ class MessageRepositoryTest {
     @Autowired ChatService chatService;
     @Autowired PartyRepository partyRepository;
     @Autowired MemberRepository memberRepository;
+    @Autowired
+    PartyService partyService;
+    @Autowired
+    MessageService messageService;
 
     @Test
     public void findLastMessageIdTest() {
@@ -36,5 +43,18 @@ class MessageRepositoryTest {
 
         // then
 
+    }
+
+    @Test
+    public void countByPartyIdAndIdGreaterThan(){
+        Member memberA = Member.builder().nickname("memberA").build();
+        Member savedMember = memberRepository.save(memberA);
+        Party partyA = Party.builder().title("hello").goalNumber(3).build();
+        Party party = partyService.create(partyA, savedMember.getId(), null);
+        messageService.send(party.getId(), savedMember.getId(), "hello");
+        messageService.send(party.getId(), savedMember.getId(), "hello2");
+
+        Integer cnt = messageRepository.countByPartyIdAndIdGreaterThan(party.getId(), 0L);
+        Assertions.assertThat(cnt).isEqualTo(3);
     }
 }

--- a/src/test/java/nbbang/com/nbbang/domain/member/controller/MyPartiesControllerTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/member/controller/MyPartiesControllerTest.java
@@ -1,0 +1,120 @@
+package nbbang.com.nbbang.domain.member.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import nbbang.com.nbbang.domain.chat.service.MessageService;
+import nbbang.com.nbbang.domain.member.domain.Member;
+import nbbang.com.nbbang.domain.member.repository.MemberRepository;
+import nbbang.com.nbbang.domain.member.service.MemberService;
+import nbbang.com.nbbang.domain.party.controller.PartyController;
+import nbbang.com.nbbang.domain.party.domain.Party;
+import nbbang.com.nbbang.domain.party.dto.many.PartyListResponseDto;
+import nbbang.com.nbbang.domain.party.dto.my.MyPartyListResponseDto;
+import nbbang.com.nbbang.domain.party.dto.single.request.PartyRequestDto;
+import nbbang.com.nbbang.domain.party.service.ManyPartyService;
+import nbbang.com.nbbang.domain.party.service.PartyMemberService;
+import nbbang.com.nbbang.domain.party.service.PartyService;
+import nbbang.com.nbbang.global.interceptor.PartyMemberInterceptorTestDto;
+import nbbang.com.nbbang.global.response.DefaultResponse;
+import nbbang.com.nbbang.global.socket.StompChannelInterceptor;
+import nbbang.com.nbbang.global.support.controller.ControllerTestParent;
+import nbbang.com.nbbang.global.support.controller.ControllerTestUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static nbbang.com.nbbang.domain.member.dto.Place.SINCHON;
+import static nbbang.com.nbbang.global.response.StatusCode.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({ControllerTestUtil.class})
+@Slf4j
+@Transactional
+@ActiveProfiles("test")
+class MyPartiesControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ControllerTestUtil controllerTestUtil;
+    @Autowired PartyService partyService;
+    @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyMemberService partyMemberService;
+    @Autowired MessageService messageService;
+    @Autowired StompChannelInterceptor stompChannelInterceptor;
+    @Autowired ManyPartyService manyPartyService;
+
+    @Test
+    void partiesOn() throws Exception {
+
+
+        Member member = Member.builder().nickname("test member").build();
+        Member saveMember1 = memberRepository.save(member);
+        Party party = Party.builder().title("tempParty").place(SINCHON).goalNumber(4).build();
+        Party savedParty = partyService.create(party, saveMember1.getId(), null);
+        Long partyId = savedParty.getId();
+        Member member2 = Member.builder().nickname("test member").build();
+        Member saveMember2 = memberRepository.save(member2);
+        Member member3 = Member.builder().nickname("test member").build();
+        Member saveMember3 = memberRepository.save(member3);
+
+        join(partyId, saveMember2.getId());
+        join(partyId, saveMember3.getId());
+
+
+        //when
+        Map<String, Object> member1Attributes = new HashMap<>();
+        Map<String, Object> member2Attributes = new HashMap<>();
+        Map<String, Object> member3Attributes = new HashMap<>();
+        //
+        stompChannelInterceptor.connect(member1Attributes, saveMember1.getId());
+        stompChannelInterceptor.connect(member2Attributes, saveMember2.getId());
+        stompChannelInterceptor.connect(member3Attributes, saveMember3.getId());
+
+        stompChannelInterceptor.enterChatRoom(member1Attributes, partyId); // 1번 파티 입장
+        Long messageId1 = messageService.send(partyId, saveMember1.getId(), "hello");
+
+        stompChannelInterceptor.exitChatRoom(member1Attributes, partyId); // 1번 파티 나감
+
+        stompChannelInterceptor.enterChatRoom(member2Attributes, partyId); // 2번 파티 입장
+
+        Long messageId2 = messageService.send(partyId, saveMember2.getId(), "hello here 2");
+
+        stompChannelInterceptor.enterChatRoom(member3Attributes, partyId); // 3번 파티 입장
+
+        Long messageId3 = messageService.send(partyId, saveMember3.getId(), "hello here 3");
+
+
+
+        DefaultResponse res = controllerTestUtil.expectDefaultResponseObject(get("/members/parties/on"));
+        MyPartyListResponseDto result = controllerTestUtil.convert(res.getData(), MyPartyListResponseDto.class);
+        assertThat(result.getParties().get(0).getNotReadNumber()).isEqualTo(2);
+
+        stompChannelInterceptor.enterChatRoom(member1Attributes, partyId); // 1번 파티 입장
+        stompChannelInterceptor.exitChatRoom(member1Attributes, partyId); // 1번 파티 나감
+
+        DefaultResponse res2 = controllerTestUtil.expectDefaultResponseObject(get("/members/parties/on"));
+        MyPartyListResponseDto result2 = controllerTestUtil.convert(res2.getData(), MyPartyListResponseDto.class);
+        assertThat(result2.getParties().get(0).getNotReadNumber()).isEqualTo(0);
+
+    }
+
+    void join(Long partyId, Long memberId) {
+        Party party = partyService.findById(partyId);
+        Member member = memberService.findById(memberId);
+        partyMemberService.joinParty(party, member);
+    }
+}

--- a/src/test/java/nbbang/com/nbbang/domain/member/controller/MyPartiesControllerTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/member/controller/MyPartiesControllerTest.java
@@ -104,11 +104,21 @@ class MyPartiesControllerTest {
         assertThat(result.getParties().get(0).getNotReadNumber()).isEqualTo(2);
 
         stompChannelInterceptor.enterChatRoom(member1Attributes, partyId); // 1번 파티 입장
-        stompChannelInterceptor.exitChatRoom(member1Attributes, partyId); // 1번 파티 나감
 
         DefaultResponse res2 = controllerTestUtil.expectDefaultResponseObject(get("/members/parties/on"));
         MyPartyListResponseDto result2 = controllerTestUtil.convert(res2.getData(), MyPartyListResponseDto.class);
         assertThat(result2.getParties().get(0).getNotReadNumber()).isEqualTo(0);
+
+        Long messageId4 = messageService.send(partyId, saveMember3.getId(), "hoho 3");
+
+
+        DefaultResponse res3 = controllerTestUtil.expectDefaultResponseObject(get("/members/parties/on"));
+        MyPartyListResponseDto result3 = controllerTestUtil.convert(res3.getData(), MyPartyListResponseDto.class);
+        assertThat(result3.getParties().get(0).getNotReadNumber()).isEqualTo(0);
+
+
+        stompChannelInterceptor.exitChatRoom(member1Attributes, partyId); // 1번 파티 나감
+
 
     }
 

--- a/src/test/java/nbbang/com/nbbang/domain/party/controller/ManyPartyControllerTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/party/controller/ManyPartyControllerTest.java
@@ -10,6 +10,7 @@ import nbbang.com.nbbang.domain.party.domain.PartyStatus;
 import nbbang.com.nbbang.domain.party.dto.many.PartyListRequestFilterDto;
 import nbbang.com.nbbang.domain.party.dto.many.PartyListResponseDto;
 import nbbang.com.nbbang.domain.party.service.ManyPartyService;
+import nbbang.com.nbbang.domain.party.service.PartyMemberService;
 import nbbang.com.nbbang.global.interceptor.CurrentMember;
 import nbbang.com.nbbang.global.response.DefaultResponse;
 import nbbang.com.nbbang.global.support.controller.ControllerTestParent;


### PR DESCRIPTION
- 나의 파티 목록 조회 시 api가 /members/parties/on으로 들어오는 코드를 수정하였습니다. 
- 소켓으로 채팅을 읽고 있는 경우 읽지 않은 개수를 0개로 전송합니다. 
- 점호 때 논의 한 내용 중, 빵판 isSent로 수정하는 것도 포함되어 있습니다. 