### PR TITLE
DB에 읽은 수가 아닌 읽지 않은 수를 저장

### DIFF
--- a/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/controller/ChatRoomController.java
@@ -18,6 +18,7 @@ import nbbang.com.nbbang.domain.party.service.PartyService;
 import nbbang.com.nbbang.global.dto.PageableDto;
 import nbbang.com.nbbang.global.interceptor.CurrentMember;
 import nbbang.com.nbbang.global.response.DefaultResponse;
+import nbbang.com.nbbang.global.socket.ChatRoomService;
 import nbbang.com.nbbang.global.socket.SocketSender;
 import nbbang.com.nbbang.global.response.StatusCode;
 import nbbang.com.nbbang.global.validator.PartyMemberValidator;
@@ -43,6 +44,7 @@ public class ChatRoomController {
     private final PartyService partyService;
     private final PartyRepository partyRepository;
     private final CurrentMember currentMember;
+    private final ChatRoomService chatRoomService;
 
     @Operation(summary = "채팅방 조회", description = "채팅방을 파티 id 로 조회합니다. ")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChatResponseDto.class)))
@@ -52,6 +54,7 @@ public class ChatRoomController {
         if (pageSize == null) {
             pageSize = 10;
         }
+        chatRoomService.readMessage(partyId, currentMember.id());
         Party party = partyService.findById(partyId);
         Page<Message> messages = chatService.findMessages(party, PageRequest.of(0, pageSize));
         return DefaultResponse.res(StatusCode.OK, ChatResponseMessage.READ_CHAT, ChatResponseDto.createByPartyAndMessagesEntity(party, messages.getContent(), currentMember.id()));

--- a/src/main/java/nbbang/com/nbbang/domain/chat/domain/Message.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/domain/Message.java
@@ -25,8 +25,7 @@ public class Message implements Comparable<Message> {
     @Column(updatable = false)
     private LocalDateTime createTime;
 
-    @Builder.Default
-    private Integer readNumber=0;
+    private Integer notReadNumber;
 
     @Column(columnDefinition = "TEXT")
     private String content;
@@ -44,13 +43,13 @@ public class Message implements Comparable<Message> {
 
     protected Message() {}
 
-    public static Message createMessage(Member sender, Party party, String content, MessageType type, Integer readNumber) {
+    public static Message createMessage(Member sender, Party party, String content, MessageType type, Integer notReadNumber) {
         return Message.builder()
                 .sender(sender)
                 .party(party)
                 .content(content)
                 .type(type)
-                .readNumber(readNumber)
+                .notReadNumber(notReadNumber)
                 .build();
     }
 

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/ReadMessageDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/ReadMessageDto.java
@@ -1,0 +1,11 @@
+package nbbang.com.nbbang.domain.chat.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReadMessageDto {
+    private Long lastReadMessageId;
+    private Long senderId;
+}

--- a/src/main/java/nbbang/com/nbbang/domain/chat/dto/message/ChatSendResponseDto.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/dto/message/ChatSendResponseDto.java
@@ -29,11 +29,10 @@ public class ChatSendResponseDto {
     private ChatSendResponseSenderDto sender;
 
     public static ChatSendResponseDto createByMessage(Message message) {
-        Integer partyMemberNumber =message.getParty().countPartyMemberNumber();
         return ChatSendResponseDto.builder()
                 .id(message.getId())
                 .createTime(message.getCreateTime())
-                .notReadNumber(partyMemberNumber - message.getReadNumber())
+                .notReadNumber(message.getNotReadNumber())
                 .type(message.getType()!=null?message.getType():MessageType.CHAT)
                 .content(message.getContent())
                 .sender(message.getSender()!=null?ChatSendResponseSenderDto.create(message.getSender()):null)

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositorySupport.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositorySupport.java
@@ -3,12 +3,9 @@ package nbbang.com.nbbang.domain.chat.repository;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MessageRepositorySupport {
     Message findLastMessage(Long partyId);
     Page<Message> findAllByCursorId(Long partyId, Pageable pageable, Long cursorId);
-    void bulkReadNumberPlus(Long lastReadId, Long partyId);
+    void bulkNotReadMinusPlus(Long lastReadId, Long partyId);
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositorySupportImpl.java
@@ -3,6 +3,7 @@ package nbbang.com.nbbang.domain.chat.repository;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.chat.domain.Message;
 import nbbang.com.nbbang.domain.chat.domain.QMessage;
 import nbbang.com.nbbang.domain.party.domain.Party;
@@ -15,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Slf4j
 public class MessageRepositorySupportImpl implements MessageRepositorySupport {
 
     private final JPAQueryFactory query;
@@ -59,5 +61,6 @@ public class MessageRepositorySupportImpl implements MessageRepositorySupport {
                 .execute();
         em.flush();
         em.clear();
+        log.info("[Add] read number 1 gt{}", lastReadId);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositorySupportImpl.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/repository/MessageRepositorySupportImpl.java
@@ -51,16 +51,16 @@ public class MessageRepositorySupportImpl implements MessageRepositorySupport {
     }
 
     @Override
-    public void bulkReadNumberPlus(Long lastReadId, Long partyId) {
+    public void bulkNotReadMinusPlus(Long lastReadId, Long partyId) {
         QMessage message = QMessage.message;
                 query
                 .update(message)
-                .set(message.readNumber,message.readNumber.add(1)) // (1)
+                .set(message.notReadNumber,message.notReadNumber.subtract(1))
                 .where(message.id.gt(lastReadId))
                 .where(message.party.id.eq(partyId))
                 .execute();
         em.flush();
         em.clear();
-        log.info("[Add] read number 1 gt{}", lastReadId);
+        log.info("[Subtract] Not Read Number -1 gt{}", lastReadId);
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -72,7 +72,7 @@ public class ChatService {
             throw new NotPartyMemberException();
         }
 
-        Message message = Message.createMessage(member, party, content, localDateTime);
+        Message message = Message.createMessage(member, party, content, localDateTime); // 수정
         messageRepository.save(message);
         return message.getId();
     }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -2,7 +2,6 @@ package nbbang.com.nbbang.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import nbbang.com.nbbang.domain.bbangpan.domain.BreadBoardPartyMemberService;
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage;
@@ -12,7 +11,6 @@ import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
-import nbbang.com.nbbang.domain.party.domain.PartyStatus;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
 import nbbang.com.nbbang.domain.party.service.PartyService;
 import nbbang.com.nbbang.global.error.exception.NotPartyMemberException;
@@ -72,7 +70,7 @@ public class ChatService {
             throw new NotPartyMemberException();
         }
 
-        Message message = Message.createMessage(member, party, content, localDateTime); // 수정
+        Message message = Message.createMessage(member, party, content, localDateTime);
         messageRepository.save(message);
         return message.getId();
     }
@@ -83,7 +81,7 @@ public class ChatService {
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
 
         Long lastReadMessageId = ((Optional.ofNullable(partyMember.getLastReadMessage())).orElse(Message.builder().id(-1L).build())).getId();
-        messageRepository.bulkReadNumberPlus(lastReadMessageId, partyId);
+        messageRepository.bulkNotReadMinusPlus(lastReadMessageId, partyId);
 
         PartyMember reFoundPartyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
         Message currentLastMessage = partyService.findLastMessage(partyId);

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/ChatService.java
@@ -7,6 +7,7 @@ import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage;
 import nbbang.com.nbbang.domain.chat.domain.Message;
+import nbbang.com.nbbang.domain.chat.dto.ReadMessageDto;
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
@@ -77,7 +78,7 @@ public class ChatService {
     }
 
     @Transactional
-    public Long readMessage(Long partyId, Long memberId) {
+    public ReadMessageDto readMessage(Long partyId, Long memberId) {
 
         PartyMember partyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
 
@@ -87,7 +88,8 @@ public class ChatService {
         PartyMember reFoundPartyMember = partyMemberRepository.findByMemberIdAndPartyId(memberId, partyId);
         Message currentLastMessage = partyService.findLastMessage(partyId);
         reFoundPartyMember.changeLastReadMessage(currentLastMessage);
-        return lastReadMessageId;
+        ReadMessageDto dto = ReadMessageDto.builder().lastReadMessageId(lastReadMessageId).senderId(memberId).build();
+        return dto;
     }
 
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
@@ -9,6 +9,7 @@ import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
+import nbbang.com.nbbang.domain.party.service.PartyService;
 import nbbang.com.nbbang.global.FileUpload.FileUploadService;
 import nbbang.com.nbbang.global.socket.service.SocketPartyMemberService;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import org.webjars.NotFoundException;
 import java.io.IOException;
 
 import static nbbang.com.nbbang.domain.chat.controller.ChatResponseMessage.MESSAGE_NOT_FOUND;
+import static nbbang.com.nbbang.domain.chat.domain.MessageType.IMAGE;
 import static nbbang.com.nbbang.domain.party.controller.PartyResponseMessage.PARTY_NOT_FOUND;
 import static nbbang.com.nbbang.global.FileUpload.UploadDirName.DIR_CHATS;
 
@@ -32,7 +34,7 @@ public class MessageService {
     private final PartyRepository partyRepository;
     private final MemberService memberService;
     private final FileUploadService fileUploadService;
-    private final SocketPartyMemberService socketPartyMemberService;
+    private final PartyService partyService;
 
     @Transactional
     public Message send(Long partyId, Long senderId, String content) {
@@ -43,11 +45,12 @@ public class MessageService {
     public Message send(Long partyId, Long senderId, String content, MessageType type) {
         Party party = partyRepository.findById(partyId).orElseThrow(()->new NotFoundException(PARTY_NOT_FOUND));
         Member sender = memberService.findById(senderId);
-        Integer readNumber = socketPartyMemberService.getActiveNumber(partyId);
-        Message message =Message.createMessage(sender, party, content, type, readNumber);
+        Integer notReadNumber = partyService.getNotActiveNumber(partyId);
+        Message message =Message.createMessage(sender, party, content, type, notReadNumber);
         Message savedMessage = messageRepository.save(message);
         return savedMessage;
     }
+
 
     public Message findById(Long id){
         return messageRepository.findById(id).orElseThrow(()->new NotFoundException(MESSAGE_NOT_FOUND));
@@ -57,13 +60,7 @@ public class MessageService {
     public Message sendImage(Long partyId, Long senderId, MultipartFile imgFile) throws IOException {
 
         String uploadUrl = fileUploadService.upload(imgFile, DIR_CHATS);
-
-        Party party = partyRepository.findById(partyId).orElseThrow(()->new NotFoundException(PARTY_NOT_FOUND));
-        Member sender = memberService.findById(senderId);
-        Integer readNumber = socketPartyMemberService.getActiveNumber(partyId);
-        Message message =Message.createMessage(sender, party, uploadUrl, MessageType.IMAGE, readNumber);
-        Message savedMessage = messageRepository.save(message);
-        return savedMessage;
+        return send(partyId, senderId, uploadUrl,IMAGE);
     }
 
 }

--- a/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/chat/service/MessageService.java
@@ -7,6 +7,7 @@ import nbbang.com.nbbang.domain.chat.domain.MessageType;
 import nbbang.com.nbbang.domain.chat.repository.MessageRepository;
 import nbbang.com.nbbang.domain.member.domain.Member;
 import nbbang.com.nbbang.domain.member.service.MemberService;
+import nbbang.com.nbbang.domain.party.controller.PartyResponseMessage;
 import nbbang.com.nbbang.domain.party.domain.Party;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
 import nbbang.com.nbbang.domain.party.service.PartyService;
@@ -34,7 +35,7 @@ public class MessageService {
     private final PartyRepository partyRepository;
     private final MemberService memberService;
     private final FileUploadService fileUploadService;
-    private final PartyService partyService;
+    private final SocketPartyMemberService socketPartyMemberService;
 
     @Transactional
     public Message send(Long partyId, Long senderId, String content) {
@@ -45,10 +46,16 @@ public class MessageService {
     public Message send(Long partyId, Long senderId, String content, MessageType type) {
         Party party = partyRepository.findById(partyId).orElseThrow(()->new NotFoundException(PARTY_NOT_FOUND));
         Member sender = memberService.findById(senderId);
-        Integer notReadNumber = partyService.getNotActiveNumber(partyId);
+
+        Integer notReadNumber = getNotActiveNumber(party);
         Message message =Message.createMessage(sender, party, content, type, notReadNumber);
         Message savedMessage = messageRepository.save(message);
         return savedMessage;
+    }
+    public Integer getNotActiveNumber(Party party) {
+        Integer activeNumber = socketPartyMemberService.getPartyActiveNumber(party.getId());
+        Integer partyMemberNumber = party.countPartyMemberNumber();
+        return partyMemberNumber - activeNumber;
     }
 
 

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -13,6 +13,7 @@ import nbbang.com.nbbang.domain.party.dto.single.PartyUpdateServiceDto;
 import nbbang.com.nbbang.domain.party.repository.PartyHashtagRepository;
 import nbbang.com.nbbang.domain.party.repository.PartyRepository;
 import nbbang.com.nbbang.global.error.exception.NotOwnerException;
+import nbbang.com.nbbang.global.socket.service.SocketPartyMemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
@@ -35,10 +36,10 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final PartyHashtagRepository partyHashtagRepository;
     private final HashtagService hashtagService;
-    private final PartyMemberRepository partyMemberRepository;
     private final MemberService memberService;
     private final PartyMemberService partyMemberService;
     private final MessageRepository messageRepository;
+    private final SocketPartyMemberService socketPartyMemberService;
 
     @Transactional
     public Party create(Party party, Long memberId, List<String> hashtagContents) {
@@ -162,5 +163,11 @@ public class PartyService {
         return partyMembers.stream()
                 .map(partyMember -> partyMember.getMember()).collect(Collectors.toList());
 
+    }
+
+    public Integer getNotActiveNumber(Long partyId)  {
+        Integer activeNumber = socketPartyMemberService.getPartyActiveNumber(partyId);
+        Integer partyMemberNumber = findById(partyId).countPartyMemberNumber();
+        return partyMemberNumber - activeNumber;
     }
 }

--- a/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
+++ b/src/main/java/nbbang/com/nbbang/domain/party/service/PartyService.java
@@ -134,12 +134,6 @@ public class PartyService {
         hashtagService.deleteIfNotReferred(partyHashtag.getHashtag());
     }
 
-    public Integer countPartyMemberNumber(Long partyId) {
-        Party party = findById(partyId);
-        Integer partyMemberNumber = party.countPartyMemberNumber();
-        return partyMemberNumber;
-    }
-
     public Message findLastMessage(Long partyId) {
         Message lastMessage = messageRepository.findLastMessage(partyId);
         return Optional.ofNullable(lastMessage).orElse(Message.builder().id(0L).build());
@@ -165,9 +159,4 @@ public class PartyService {
 
     }
 
-    public Integer getNotActiveNumber(Long partyId)  {
-        Integer activeNumber = socketPartyMemberService.getPartyActiveNumber(partyId);
-        Integer partyMemberNumber = findById(partyId).countPartyMemberNumber();
-        return partyMemberNumber - activeNumber;
-    }
 }

--- a/src/main/java/nbbang/com/nbbang/global/socket/ChatRoomService.java
+++ b/src/main/java/nbbang/com/nbbang/global/socket/ChatRoomService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import nbbang.com.nbbang.domain.bbangpan.domain.PartyMember;
 import nbbang.com.nbbang.domain.bbangpan.repository.PartyMemberRepository;
 import nbbang.com.nbbang.domain.chat.dto.ChatReadSocketDto;
+import nbbang.com.nbbang.domain.chat.dto.ReadMessageDto;
 import nbbang.com.nbbang.domain.chat.service.ChatService;
 import nbbang.com.nbbang.domain.party.service.PartyMemberService;
 import nbbang.com.nbbang.domain.party.service.PartyService;
@@ -42,16 +43,14 @@ public class ChatRoomService {
     public void enter(Map<String, Object> attributes, Long partyId){
         attributes.put("partyId", partyId);
         Long memberId = (Long) attributes.get("memberId");
-        readMessage(partyId, memberId);
         socketPartyMemberService.subscribe(partyId, memberId);
         attributes.put("status", "subscribe");
     }
 
     @Transactional
     public void readMessage(Long partyId, Long memberId) {
-        Long lastReadMessageId = chatService.readMessage(partyId, memberId);
-        ChatReadSocketDto chatReadSocketDto = ChatReadSocketDto.builder().lastReadMessageId(lastReadMessageId).build();
-        socketSender.sendChattingReadMessage(partyId, chatReadSocketDto);
+        ReadMessageDto readMessageDto = chatService.readMessage(partyId, memberId);
+        socketSender.sendChattingReadMessage(partyId, readMessageDto);
     }
 
     @Transactional

--- a/src/main/java/nbbang/com/nbbang/global/socket/repository/MemorySocketPartyMemberRepository.java
+++ b/src/main/java/nbbang/com/nbbang/global/socket/repository/MemorySocketPartyMemberRepository.java
@@ -31,7 +31,7 @@ public class MemorySocketPartyMemberRepository implements SocketPartyMemberRepos
     }
 
     @Override
-    public Integer getActiveNumber(PartyMemberPair pair) {
+    public Integer getPartyMemberActiveNumber(PartyMemberPair pair) {
         return sessionPartyMap.get(pair);
     }
 

--- a/src/main/java/nbbang/com/nbbang/global/socket/repository/RedisSocketPartyMemberRepository.java
+++ b/src/main/java/nbbang/com/nbbang/global/socket/repository/RedisSocketPartyMemberRepository.java
@@ -43,7 +43,7 @@ public class RedisSocketPartyMemberRepository implements SocketPartyMemberReposi
     }
 
     @Override
-    public Integer getActiveNumber(PartyMemberPair pair){
+    public Integer getPartyMemberActiveNumber(PartyMemberPair pair){
         return opsHashChatRoom.get(CHAT_ROOM, pair);
     }
 

--- a/src/main/java/nbbang/com/nbbang/global/socket/repository/SocketPartyMemberRepository.java
+++ b/src/main/java/nbbang/com/nbbang/global/socket/repository/SocketPartyMemberRepository.java
@@ -9,6 +9,6 @@ public interface SocketPartyMemberRepository {
     void updateActiveNumber(PartyMemberPair pair, Integer cnt);
     Map getAllEntries();
     Boolean hasKey(PartyMemberPair pair);
-    Integer getActiveNumber(PartyMemberPair pair);
+    Integer getPartyMemberActiveNumber(PartyMemberPair pair);
 
 }

--- a/src/main/java/nbbang/com/nbbang/global/socket/service/SocketPartyMemberService.java
+++ b/src/main/java/nbbang/com/nbbang/global/socket/service/SocketPartyMemberService.java
@@ -23,13 +23,13 @@ public class SocketPartyMemberService {
     public void unsubscribe(Long partyId, Long memberId) {
         PartyMemberPair pair = PartyMemberPair.create(partyId, memberId);
 
-        if (!socketPartyMemberRepository.hasKey(pair) || socketPartyMemberRepository.getActiveNumber(pair) < 1){
+        if (!socketPartyMemberRepository.hasKey(pair) || socketPartyMemberRepository.getPartyMemberActiveNumber(pair) < 1){
             throw new IllegalArgumentException("[UNSUBSCRIBE ERROR] partyId, memberId에 해당하는 소켓 연결을 찾을 수 없습니다.");
         }
         socketPartyMemberRepository.updateActiveNumber(pair, -1);
     }
 
-    public Integer getActiveNumber(Long partyId) {
+    public Integer getPartyActiveNumber(Long partyId) {
         Map<PartyMemberPair, Integer> entries = socketPartyMemberRepository.getAllEntries();
         long count = entries.entrySet().stream().filter(entry -> entry.getKey().getPartyId().equals(partyId) && entry.getValue() > 0).count();
         return Integer.valueOf((int) count);
@@ -37,7 +37,7 @@ public class SocketPartyMemberService {
 
     public Boolean isActive(Long partyId, Long memberId) {
         PartyMemberPair pair = PartyMemberPair.create(partyId, memberId);
-        if(socketPartyMemberRepository.hasKey(pair) &&  socketPartyMemberRepository.getActiveNumber(pair) > 0){
+        if(socketPartyMemberRepository.hasKey(pair) &&  socketPartyMemberRepository.getPartyMemberActiveNumber(pair) > 0){
             return true;
         }
         return false;

--- a/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
+++ b/src/test/java/nbbang/com/nbbang/domain/chat/service/ChatReadTest.java
@@ -66,31 +66,37 @@ class ChatReadTest {
         stompChannelInterceptor.connect(member3Attributes);
 
         chatRoomService.enter(member1Attributes, partyId); // 1번 파티 입장
+        chatRoomService.readMessage(partyId, saveMember1.getId());
         Long messageId1 = messageService.send(partyId, saveMember1.getId(), "hello").getId();
-        assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(1);
+        assertThat(messageService.findById(messageId1).getNotReadNumber()).isEqualTo(2);
 
         chatRoomService.enter(member2Attributes, partyId); // 2번 파티 입장
-        assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
+        chatRoomService.readMessage(partyId, saveMember2.getId());
+        assertThat(messageService.findById(messageId1).getNotReadNumber()).isEqualTo(1);
 
         Long messageId2 = messageService.send(partyId, saveMember2.getId(), "hello here 2").getId();
-        assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
-        assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(2);
+        assertThat(messageService.findById(messageId1).getNotReadNumber()).isEqualTo(1);
+        assertThat(messageService.findById(messageId2).getNotReadNumber()).isEqualTo(1);
 
         chatRoomService.exit(member1Attributes, partyId); // 1번 파티 나감
-        assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(2);
+        assertThat(messageService.findById(messageId1).getNotReadNumber()).isEqualTo(1);
 
         chatRoomService.enter(member3Attributes, partyId); // 3번 파티 입장
+        chatRoomService.readMessage(partyId, saveMember3.getId());
 
-        assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(3);
-        assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(3);
+
+        assertThat(messageService.findById(messageId1).getNotReadNumber()).isEqualTo(0);
+        assertThat(messageService.findById(messageId2).getNotReadNumber()).isEqualTo(0);
 
         Long messageId3 = messageService.send(partyId, saveMember3.getId(), "hello here 3").getId();
-        assertThat(messageService.findById(messageId3).getReadNumber()).isEqualTo(2);
+        assertThat(messageService.findById(messageId3).getNotReadNumber()).isEqualTo(1);
 
         chatRoomService.enter(member1Attributes, partyId); // 1번 파티 입장
-        assertThat(messageService.findById(messageId1).getReadNumber()).isEqualTo(3);
-        assertThat(messageService.findById(messageId2).getReadNumber()).isEqualTo(3);
-        assertThat(messageService.findById(messageId3).getReadNumber()).isEqualTo(3);
+        chatRoomService.readMessage(partyId, saveMember1.getId());
+
+        assertThat(messageService.findById(messageId1).getNotReadNumber()).isEqualTo(0);
+        assertThat(messageService.findById(messageId2).getNotReadNumber()).isEqualTo(0);
+        assertThat(messageService.findById(messageId3).getNotReadNumber()).isEqualTo(0);
 
     }
 


### PR DESCRIPTION
- 채팅방에 새로운 사람이 들어가면 그 이전 채팅도 읽지 않은 수가 늘어나는 문제가 있었습니다. 
- 따라서 읽지 않은 수를 저장해둬서, 채팅방에 새 유저가 들어와도 채팅 읽지 않은 수가 줄어들지 않도록 처리합니다. 